### PR TITLE
IBX-538: Replaced EzPublishCore Twig namespace references with IbexaCore

### DIFF
--- a/src/bundle/Resources/views/RichText/content_fields.html.twig
+++ b/src/bundle/Resources/views/RichText/content_fields.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain "content_fields" %}
 
-{% extends "@EzPublishCore/content_fields.html.twig" %}
+{% extends "@IbexaCore/content_fields.html.twig" %}
 
 {% block ezrichtext_field %}
     {%- set field_value = field.value.xml|ez_richtext_to_html5 -%}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-538](https://issues.ibexa.co/browse/IBX-538)
| **Requires**                            | ibexa/core#13
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes

ibexa/core#13 updates `ibexa/core` Bundle names with proper Ibexa prefix instead of EzPublish. This PR aligns Twig namespace references with the bundle name change.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Asked for a review