### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
+++ b/src/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
@@ -24,13 +24,17 @@ class RichTextHtml5ConverterPass implements CompilerPassInterface
     {
         if ($container->hasDefinition('ezrichtext.converter.output.xhtml5')) {
             $html5OutputConverterDefinition = $container->getDefinition('ezrichtext.converter.output.xhtml5');
-            $taggedOutputServiceIds = $container->findTaggedServiceIds('ezrichtext.converter.output.xhtml5');
+            $taggedOutputServiceIds = $container->findTaggedServiceIds(
+                'ibexa.field_type.richtext.converter.output.xhtml5'
+            );
             $this->setConverterDefinitions($taggedOutputServiceIds, $html5OutputConverterDefinition);
         }
 
         if ($container->hasDefinition('ezrichtext.converter.input.xhtml5')) {
             $html5InputConverterDefinition = $container->getDefinition('ezrichtext.converter.input.xhtml5');
-            $taggedInputServiceIds = $container->findTaggedServiceIds('ezrichtext.converter.input.xhtml5');
+            $taggedInputServiceIds = $container->findTaggedServiceIds(
+                'ibexa.field_type.richtext.converter.input.xhtml5'
+            );
             $this->setConverterDefinitions($taggedInputServiceIds, $html5InputConverterDefinition);
         }
     }

--- a/src/bundle/DependencyInjection/IbexaFieldTypeRichTextExtension.php
+++ b/src/bundle/DependencyInjection/IbexaFieldTypeRichTextExtension.php
@@ -28,7 +28,7 @@ class IbexaFieldTypeRichTextExtension extends Extension implements PrependExtens
     public const RICHTEXT_CUSTOM_STYLES_PARAMETER = 'ezplatform.ezrichtext.custom_styles';
     public const RICHTEXT_CUSTOM_TAGS_PARAMETER = 'ezplatform.ezrichtext.custom_tags';
     public const RICHTEXT_ALLOY_EDITOR_PARAMETER = 'ezplatform.ezrichtext.alloy_editor';
-    public const RICHTEXT_CONFIGURATION_PROVIDER_TAG = 'ezplatform.ezrichtext.configuration.provider';
+    public const RICHTEXT_CONFIGURATION_PROVIDER_TAG = 'ibexa.field_type.richtext.configuration.provider';
 
     private const RICHTEXT_TEXT_TOOLBAR_NAME = 'text';
 

--- a/src/bundle/Resources/config/configuration.yaml
+++ b/src/bundle/Resources/config/configuration.yaml
@@ -29,4 +29,4 @@ services:
 
     Ibexa\FieldTypeRichText\Configuration\AggregateProvider:
         arguments:
-            $providers: !tagged ezplatform.ezrichtext.configuration.provider
+            $providers: !tagged ibexa.field_type.richtext.configuration.provider

--- a/src/bundle/Resources/config/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/fieldtype_services.yaml
@@ -48,7 +48,7 @@ services:
         class: Ibexa\FieldTypeRichText\RichText\Converter\Link
         arguments: ['@ezpublish.api.service.location', '@ezpublish.api.service.content', '@ezpublish.urlalias_router', '@?logger']
         tags:
-            - {name: ezrichtext.converter.output.xhtml5, priority: 0}
+            - {name: ibexa.field_type.richtext.converter.output.xhtml5, priority: 0}
 
     ezrichtext.converter.template:
         class: Ibexa\FieldTypeRichText\RichText\Converter\Render\Template
@@ -57,7 +57,7 @@ services:
             - '@ezrichtext.converter.output.xhtml5'
             - '@?logger'
         tags:
-            - {name: ezrichtext.converter.output.xhtml5, priority: 10}
+            - {name: ibexa.field_type.richtext.converter.output.xhtml5, priority: 10}
         lazy: true
 
     ezrichtext.converter.embed:
@@ -66,14 +66,14 @@ services:
             - '@ezrichtext.renderer'
             - '@?logger'
         tags:
-            - {name: ezrichtext.converter.output.xhtml5, priority: 10}
+            - {name: ibexa.field_type.richtext.converter.output.xhtml5, priority: 10}
 
     # Note: should typically be the last one as it produces embeddable fragment
     ezrichtext.converter.output.xhtml5.fragment:
         class: Ibexa\FieldTypeRichText\RichText\Converter\Xslt
         arguments: ['%ezrichtext.converter.output.xhtml5.fragment.resources%']
         tags:
-            - {name: ezrichtext.converter.output.xhtml5, priority: 100}
+            - {name: ibexa.field_type.richtext.converter.output.xhtml5, priority: 100}
 
     # Aggregate converter for XHTML5 output that other converters register to
     # through service tags.
@@ -83,13 +83,13 @@ services:
 
     ezrichtext.validator.input.ezxhtml5:
         class: Ibexa\FieldTypeRichText\RichText\Validator\ValidatorAggregate
-        arguments: [!tagged ezrichtext.validator.input.ezxhtml5]
+        arguments: [!tagged ibexa.field_type.richtext.validator.input.xhtml5]
 
     ezrichtext.validator.docbook:
         class: Ibexa\FieldTypeRichText\RichText\Validator\Validator
         arguments: ['%ezrichtext.validator.docbook.resources%']
         tags:
-            - { name: 'ezrichtext.validator.input.ezxhtml5' }
+            - { name: ibexa.field_type.richtext.validator.input.xhtml5 }
 
     ezrichtext.validator.output.ezxhtml5:
         class: Ibexa\FieldTypeRichText\RichText\Validator\Validator
@@ -109,7 +109,7 @@ services:
             - '@ezpublish.spi.persistence.cache.contentHandler'
             - '@ezpublish.spi.persistence.cache.locationHandler'
         tags:
-            - { name: 'ezrichtext.validator.input.ezxhtml5' }
+            - { name: ibexa.field_type.richtext.validator.input.xhtml5 }
 
     ezrichtext.converter.output.xhtml5.core:
         class: Ibexa\FieldTypeRichText\RichText\Converter\Html5
@@ -117,10 +117,10 @@ services:
             - '%ezrichtext.converter.output.xhtml5.resources%'
             - '@ezpublish.config.resolver'
         tags:
-            - {name: ezrichtext.converter.output.xhtml5, priority: 50}
+            - {name: ibexa.field_type.richtext.converter.output.xhtml5, priority: 50}
 
     # Aggregate converter for XHTML5 input that other converters register to
-    # through 'ezrichtext.converter.input.xhtml5' service tag.
+    # through 'ibexa.field_type.richtext.converter.input.xhtml5' service tag.
     ezrichtext.converter.input.xhtml5:
         class: Ibexa\FieldTypeRichText\RichText\Converter\Aggregate
         lazy: true
@@ -131,13 +131,13 @@ services:
             - '%ezrichtext.converter.input.xhtml5.resources%'
             - '@ezpublish.config.resolver'
         tags:
-            - {name: ezrichtext.converter.input.xhtml5, priority: 50}
+            - {name: ibexa.field_type.richtext.converter.input.xhtml5, priority: 50}
 
     # Note: should run before xsl transformation
     ezrichtext.converter.input.xhtml5.programlisting:
         class: Ibexa\FieldTypeRichText\RichText\Converter\ProgramListing
         tags:
-            - {name: ezrichtext.converter.input.xhtml5, priority: 10}
+            - {name: ibexa.field_type.richtext.converter.input.xhtml5, priority: 10}
 
     ezrichtext.converter.edit.xhtml5:
         class: Ibexa\FieldTypeRichText\RichText\Converter\Html5Edit

--- a/src/bundle/Resources/config/form.yaml
+++ b/src/bundle/Resources/config/form.yaml
@@ -19,5 +19,5 @@ services:
 
     Ibexa\FieldTypeRichText\Form\Mapper\RichTextFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: ezrichtext }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: ezrichtext }
 

--- a/src/bundle/Resources/config/settings/fieldtype_external_storages.yaml
+++ b/src/bundle/Resources/config/settings/fieldtype_external_storages.yaml
@@ -2,5 +2,5 @@ services:
     Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage:
         arguments: ['@Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage']
         tags:
-            - {name: ezplatform.field_type.external_storage_handler, alias: ezrichtext}
+            - {name: ibexa.field_type.storage.external.handler, alias: ezrichtext}
         public: true

--- a/src/bundle/Resources/config/settings/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/settings/fieldtype_services.yaml
@@ -15,13 +15,13 @@ services:
 
     ezrichtext.validator.input.ezxhtml5:
         class: Ibexa\FieldTypeRichText\RichText\Validator\ValidatorAggregate
-        arguments: [!tagged ezrichtext.validator.input.ezxhtml5]
+        arguments: [!tagged ibexa.field_type.richtext.validator.input.xhtml5]
 
     ezrichtext.validator.docbook:
         class: Ibexa\FieldTypeRichText\RichText\Validator\Validator
         arguments: ['%ezrichtext.validator.docbook.resources%']
         tags:
-            - { name: 'ezrichtext.validator.input.ezxhtml5' }
+            - { name: ibexa.field_type.richtext.validator.input.xhtml5 }
 
     ezrichtext.validator.input.dispatcher:
         class: Ibexa\FieldTypeRichText\RichText\Validator\ValidatorDispatcher
@@ -35,7 +35,7 @@ services:
             - '@ezpublish.spi.persistence.cache.contentHandler'
             - '@ezpublish.spi.persistence.cache.locationHandler'
         tags:
-            - { name: 'ezrichtext.validator.input.ezxhtml5' }
+            - { name: ibexa.field_type.richtext.validator.input.xhtml5 }
 
     ezrichtext.normalizer.input:
         class: Ibexa\FieldTypeRichText\RichText\Normalizer\Aggregate
@@ -45,7 +45,7 @@ services:
         public: false
         arguments: ['%ezplatform.ezrichtext.custom_tags%']
         tags:
-            - { name: 'ezrichtext.validator.input.ezxhtml5' }
+            - { name: ibexa.field_type.richtext.validator.input.xhtml5 }
 
     Ibexa\FieldTypeRichText\RichText\RelationProcessor:
         public: false

--- a/src/bundle/Resources/config/settings/fieldtypes.yaml
+++ b/src/bundle/Resources/config/settings/fieldtypes.yaml
@@ -5,4 +5,4 @@ services:
         arguments:
             - '@Ibexa\FieldTypeRichText\RichText\InputHandler'
         tags:
-            - {name: ezplatform.field_type, alias: ezrichtext}
+            - {name: ibexa.field_type, alias: ezrichtext}

--- a/src/bundle/Resources/config/settings/indexable_fieldtypes.yaml
+++ b/src/bundle/Resources/config/settings/indexable_fieldtypes.yaml
@@ -1,4 +1,4 @@
 services:
     Ibexa\FieldTypeRichText\FieldType\RichText\SearchField:
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezrichtext}
+            - {name: ibexa.field_type.indexable, alias: ezrichtext}

--- a/src/bundle/Resources/config/settings/storage_engines/legacy/field_value_converters.yaml
+++ b/src/bundle/Resources/config/settings/storage_engines/legacy/field_value_converters.yaml
@@ -1,4 +1,4 @@
 services:
     Ibexa\FieldTypeRichText\Persistence\Legacy\RichTextFieldValueConverter:
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezrichtext}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezrichtext}

--- a/src/bundle/Resources/config/ui/mappers.yaml
+++ b/src/bundle/Resources/config/ui/mappers.yaml
@@ -11,14 +11,14 @@ services:
     # RichText Custom Tags UI config attribute type mappers
     Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag\CommonAttributeMapper:
         tags:
-            - { name: ezrichtext.configuration.custom_tag.mapper, priority: 0 }
+            - { name: ibexa.field_type.richtext.configuration.custom_tag.mapper, priority: 0 }
 
     Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag\ChoiceAttributeMapper:
         parent: Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag\CommonAttributeMapper
         autowire: true
         public: false
         tags:
-            - { name: ezrichtext.configuration.custom_tag.mapper, priority: 10 }
+            - { name: ibexa.field_type.richtext.configuration.custom_tag.mapper, priority: 10 }
 
     # RichText Custom Tags UI config mapper
     Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag:
@@ -26,7 +26,7 @@ services:
             $customTagsConfiguration: '%ezplatform.ezrichtext.custom_tags%'
             $translatorBag: '@translator'
             $translationDomain: '%ezrichtext.custom_tags.translation_domain%'
-            $customTagAttributeMappers: !tagged ezrichtext.configuration.custom_tag.mapper
+            $customTagAttributeMappers: !tagged ibexa.field_type.richtext.configuration.custom_tag.mapper
 
     # RichText Custom Styles UI config mapper
     Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomStyle:

--- a/tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
@@ -38,19 +38,19 @@ class RichTextHtml5ConverterPassTest extends AbstractCompilerPassTestCase
         );
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5');
+        $configurationProvider->addTag('ibexa.field_type.richtext.converter.output.xhtml5');
         $this->setDefinition('ezrichtext.converter.test1', $configurationProvider);
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5', ['priority' => 10]);
+        $configurationProvider->addTag('ibexa.field_type.richtext.converter.output.xhtml5', ['priority' => 10]);
         $this->setDefinition('ezrichtext.converter.test2', $configurationProvider);
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5', ['priority' => 5]);
+        $configurationProvider->addTag('ibexa.field_type.richtext.converter.output.xhtml5', ['priority' => 5]);
         $this->setDefinition('ezrichtext.converter.test3', $configurationProvider);
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5', ['priority' => 5]);
+        $configurationProvider->addTag('ibexa.field_type.richtext.converter.output.xhtml5', ['priority' => 5]);
         $this->setDefinition('ezrichtext.converter.test4', $configurationProvider);
 
         $this->compile();


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
