### PR TITLE
IBX-2028: Restored default custom tags to configuration

### DIFF
--- a/src/bundle/Resources/config/prepend/ezpublish.yaml
+++ b/src/bundle/Resources/config/prepend/ezpublish.yaml
@@ -11,6 +11,7 @@ system:
     admin_group:
         fieldtypes:
             ezrichtext:
+                custom_tags: [ezyoutube, eztwitter, ezfacebook]
                 toolbar:
                     group1:
                         priority: 60


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-2028

The problem is not with inability to add custom tags. Default custom tags (social media buttons) have been accidentally removed here: https://github.com/ibexa/fieldtype-richtext/commit/bac7c8e22f6bd5cb2e1760bc21ca2190b26a8953#diff-436dce8a20ae62140f2de6ec8dbec1533068c7f0796de0d61eb3aab6f2648589L14