### PR TITLE
IBX-1832: Removed whitespaces from image embed configuration payload

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
@@ -123,6 +123,7 @@ class IbexaEmbedImageEditing extends Plugin {
                 const config = downcastWriter.createUIElement('span', { 'data-ezelement': 'ezconfig' }, function(domDocument) {
                     const domElement = this.toDomElement(domDocument);
 
+                    // note: do not reformat - configuration value for image embeds cannot contain whitespaces
                     domElement.innerHTML = `<span data-ezelement="ezvalue" data-ezvalue-key="size">${modelElement.getAttribute('size')}</span>`;
 
                     return domElement;

--- a/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
@@ -123,9 +123,7 @@ class IbexaEmbedImageEditing extends Plugin {
                 const config = downcastWriter.createUIElement('span', { 'data-ezelement': 'ezconfig' }, function(domDocument) {
                     const domElement = this.toDomElement(domDocument);
 
-                    domElement.innerHTML = `<span data-ezelement="ezvalue" data-ezvalue-key="size">
-                        ${modelElement.getAttribute('size')}
-                    </span>`;
+                    domElement.innerHTML = `<span data-ezelement="ezvalue" data-ezvalue-key="size">${modelElement.getAttribute('size')}</span>`;
 
                     return domElement;
                 });


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1832](https://issues.ibexa.co/browse/IBX-1832)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes

Embed configuration keys cannot contain whitespaces, as there's no way to determine if given configuration key should have them trimmed or not - it's too generic at that point
```xml
<span data-ezelement="ezvalue" data-ezvalue-key="size">medium</span>
```
is the proper formatting the payload should have.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [ ] Asked for a review