### PR TITLE
IBX-2961: Fixed extensibility point for adding plugins in CKEditor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/translation": "^5.0",
         "symfony/translation-contracts": "^2.0",
         "twig/twig": "^3.0",
-        "ibexa/core": "~4.1.0@dev",
+        "ibexa/core": "~4.1.6@dev",
         "ibexa/content-forms": "~4.1.0@dev",
         "ibexa/rest": "~4.1.0@dev",
         "ibexa/http-cache": "~4.1.0@dev"

--- a/src/bundle/DependencyInjection/IbexaFieldTypeRichTextExtension.php
+++ b/src/bundle/DependencyInjection/IbexaFieldTypeRichTextExtension.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\FieldTypeRichText\DependencyInjection;
 
+use Ibexa\Contracts\Core\Container\Encore\ConfigurationDumper as IbexaEncoreConfigurationDumper;
 use Ibexa\Contracts\FieldTypeRichText\Configuration\Provider;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
@@ -31,6 +32,12 @@ class IbexaFieldTypeRichTextExtension extends Extension implements PrependExtens
     public const RICHTEXT_CONFIGURATION_PROVIDER_TAG = 'ibexa.field_type.richtext.configuration.provider';
 
     private const RICHTEXT_TEXT_TOOLBAR_NAME = 'text';
+
+    private const WEBPACK_CONFIG_NAMES = [
+        'ibexa.richtext.config.manager.js' => [
+            'ibexa.richtext.config.manager.js' => [],
+        ],
+    ];
 
     public function getAlias()
     {
@@ -77,6 +84,10 @@ class IbexaFieldTypeRichTextExtension extends Extension implements PrependExtens
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
         $this->registerRichTextConfiguration($config, $container);
+
+        (new IbexaEncoreConfigurationDumper($container))->dumpCustomConfiguration(
+            self::WEBPACK_CONFIG_NAMES
+        );
     }
 
     /**

--- a/src/bundle/Resources/encore/ez.webpack.custom.config.js
+++ b/src/bundle/Resources/encore/ez.webpack.custom.config.js
@@ -1,6 +1,8 @@
 const Encore = require('@symfony/webpack-encore');
 const path = require('path');
 const { styles } = require(path.resolve('./public/bundles/ibexaadminuiassets/vendors/@ckeditor/ckeditor5-dev-utils'));
+const ibexaConfigManager = require(path.resolve('./ibexa.webpack.config.manager.js'));
+const configManagers = require(path.resolve('./var/encore/ibexa.richtext.config.manager.js'));
 
 Encore.reset();
 Encore.setOutputPath('public/assets/richtext/build').setPublicPath('/assets/richtext/build').enableSassLoader().disableSingleRuntimeChunk();
@@ -52,5 +54,11 @@ customConfig.module.rules.push({
 
 customConfig.module.rules[1] = {};
 customConfig.module.rules[2] = {};
+
+configManagers.forEach((configManagerPath) => {
+    const configManager = require(path.resolve(configManagerPath));
+
+    configManager(customConfig, ibexaConfigManager);
+});
 
 module.exports = customConfig;

--- a/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -13,15 +13,13 @@ use Ibexa\Bundle\FieldTypeRichText\DependencyInjection\Configuration\Parser\Fiel
 use Ibexa\Bundle\FieldTypeRichText\DependencyInjection\IbexaFieldTypeRichTextExtension;
 use Ibexa\Bundle\FieldTypeRichText\IbexaFieldTypeRichTextBundle;
 use Ibexa\Tests\Bundle\Core\DependencyInjection\Configuration\Parser\AbstractParserTestCase;
-use Ibexa\Tests\Bundle\FieldTypeRichText\DependencyInjection\ContainerParameterLoaderTrait;
+use Ibexa\Tests\Bundle\FieldTypeRichText\DependencyInjection\ContainerParameterLoader;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\Yaml\Yaml;
 
 class RichTextTest extends AbstractParserTestCase
 {
-    use ContainerParameterLoaderTrait;
-
     /**
      * Multidimensional array of configuration of multiple extensions ([extension => config]).
      *
@@ -60,7 +58,7 @@ class RichTextTest extends AbstractParserTestCase
         $bundle = new IbexaFieldTypeRichTextBundle();
         $bundle->build($this->container);
 
-        $this->loadMockedRequiredContainerParameters($this->container);
+        (new ContainerParameterLoader())->loadMockedRequiredContainerParameters($this->container);
 
         $configs = array_merge_recursive($this->getMinimalConfiguration(), $configurationValues);
 

--- a/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -13,12 +13,15 @@ use Ibexa\Bundle\FieldTypeRichText\DependencyInjection\Configuration\Parser\Fiel
 use Ibexa\Bundle\FieldTypeRichText\DependencyInjection\IbexaFieldTypeRichTextExtension;
 use Ibexa\Bundle\FieldTypeRichText\IbexaFieldTypeRichTextBundle;
 use Ibexa\Tests\Bundle\Core\DependencyInjection\Configuration\Parser\AbstractParserTestCase;
+use Ibexa\Tests\Bundle\FieldTypeRichText\DependencyInjection\ContainerParameterLoaderTrait;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\Yaml\Yaml;
 
 class RichTextTest extends AbstractParserTestCase
 {
+    use ContainerParameterLoaderTrait;
+
     /**
      * Multidimensional array of configuration of multiple extensions ([extension => config]).
      *
@@ -57,11 +60,7 @@ class RichTextTest extends AbstractParserTestCase
         $bundle = new IbexaFieldTypeRichTextBundle();
         $bundle->build($this->container);
 
-        // mock list of available bundles
-        $this->setParameter(
-            'kernel.bundles',
-            ['IbexaCoreBundle' => null, 'IbexaFieldTypeRichTextBundle' => null]
-        );
+        $this->loadMockedRequiredContainerParameters($this->container);
 
         $configs = array_merge_recursive($this->getMinimalConfiguration(), $configurationValues);
 
@@ -185,9 +184,9 @@ class RichTextTest extends AbstractParserTestCase
     /**
      * Data provider for testOnlineEditorInvalidSettings.
      *
-     * @see testOnlineEditorInvalidSettingsThrowException
-     *
      * @return array
+     *
+     * @see testOnlineEditorInvalidSettingsThrowException
      */
     public function getOnlineEditorInvalidSettings(): array
     {

--- a/tests/bundle/DependencyInjection/ContainerParameterLoader.php
+++ b/tests/bundle/DependencyInjection/ContainerParameterLoader.php
@@ -10,7 +10,10 @@ namespace Ibexa\Tests\Bundle\FieldTypeRichText\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-trait ContainerParameterLoaderTrait
+/**
+ * @internal
+ */
+final class ContainerParameterLoader
 {
     public function loadMockedRequiredContainerParameters(ContainerInterface $container): void
     {

--- a/tests/bundle/DependencyInjection/ContainerParameterLoaderTrait.php
+++ b/tests/bundle/DependencyInjection/ContainerParameterLoaderTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\FieldTypeRichText\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+trait ContainerParameterLoaderTrait
+{
+    public function loadMockedRequiredContainerParameters(ContainerInterface $container): void
+    {
+        $projectDir = dirname(__DIR__, 3);
+        $container->setParameter('kernel.project_dir', $projectDir);
+        // mock list of available bundles
+        $container->setParameter(
+            'kernel.bundles',
+            ['IbexaCoreBundle' => null, 'IbexaFieldTypeRichTextBundle' => null]
+        );
+        $container->setParameter(
+            'kernel.bundles_metadata',
+            [
+                'IbexaCoreBundle' => [
+                    'path' => $projectDir . '/vendor/ibexa/core/src/bundle/Core',
+                    'namespace' > 'Ibexa\Bundle\Core',
+                ],
+                'IbexaFieldTypeRichTextBundle' => [
+                    'path' => $projectDir . '/src/bundle',
+                    'namespace' > 'Ibexa\Bundle\FieldTypeRichText',
+                ],
+            ]
+        );
+    }
+}

--- a/tests/bundle/DependencyInjection/IbexaFieldTypeRichTextExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaFieldTypeRichTextExtensionTest.php
@@ -15,8 +15,6 @@ use Symfony\Component\Yaml\Yaml;
 
 class IbexaFieldTypeRichTextExtensionTest extends AbstractExtensionTestCase
 {
-    use ContainerParameterLoaderTrait;
-
     protected function getContainerExtensions(): array
     {
         return [new IbexaFieldTypeRichTextExtension()];
@@ -26,7 +24,7 @@ class IbexaFieldTypeRichTextExtensionTest extends AbstractExtensionTestCase
     {
         parent::setUp();
 
-        $this->loadMockedRequiredContainerParameters($this->container);
+        (new ContainerParameterLoader())->loadMockedRequiredContainerParameters($this->container);
     }
 
     /**

--- a/tests/bundle/DependencyInjection/IbexaFieldTypeRichTextExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaFieldTypeRichTextExtensionTest.php
@@ -15,9 +15,18 @@ use Symfony\Component\Yaml\Yaml;
 
 class IbexaFieldTypeRichTextExtensionTest extends AbstractExtensionTestCase
 {
+    use ContainerParameterLoaderTrait;
+
     protected function getContainerExtensions(): array
     {
         return [new IbexaFieldTypeRichTextExtension()];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadMockedRequiredContainerParameters($this->container);
     }
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2961](https://issues.ibexa.co/browse/IBX-2961)
| **Requires**                            | ibexa/core#120
| **Type**                                   | bug
| **Target Ibexa version** | `v4.1`+
| **BC breaks**                          | no
| **Tests**                            | <ul><li>[Passing CI build with ibexa/core dependency](https://github.com/ibexa/fieldtype-richtext/actions/runs/2494846208)</li><li>ibexa/commerce#102</li></ul>

Related changes:
- ibexa/admin-ui#471

## Doc

See also ibexa/admin-ui#471 for Doc.

We need to extend this part of the documentation: https://doc.ibexa.co/en/latest/extending/extending_online_editor/#add-ckeditor-plugins

It is still needed to add plugin into the extraPlugins array, but it has to be done in a specific way. 
The JS cannot be added by the default configManager or added in any encore entry. It has to be added to the `ibexa-richtext-onlineeditor-js` entry.

So we introduced the new configManager which will handle adding JS to the CKEditor config.
The file that must be created is `ibexa.richtext.config.manager.js` either in the top level project folder `encore` or in a `Resources/encore/` folder in the bundle

the code for `ibexa.richtext.config.manager.js`:
```js
const path = require('path');

module.exports = (ibexaConfig, ibexaConfigManager) => {
    ibexaConfigManager.add({
        ibexaConfig,
        entryName: 'ibexa-richtext-onlineeditor-js',
        newItems: ["path_to_file"],
    });
};
```

**TODO**:
- [x] Ask for Code Review.
