### PR TITLE
IBX-2555: Fixed double content in inline custom tags

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/inline-custom-tag/inline-custom-tag-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/inline-custom-tag/inline-custom-tag-editing.js
@@ -118,19 +118,12 @@ class IbexaInlineCustomTagEditing extends Plugin {
         });
 
         conversion.for('upcast').elementToElement({
+            model: 'inlineCustomTagContent',
             view: {
                 name: 'span',
                 attributes: {
                     'data-ezelement': 'ezcontent',
                 },
-            },
-            model: (viewElement, { writer: upcastWriter }) => {
-                const content = viewElement.getChild(0);
-                const modelElement = upcastWriter.createElement('inlineCustomTagContent');
-
-                upcastWriter.insertText(content.data, modelElement);
-
-                return modelElement;
             },
         });
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-2555
| **Bug/Improvement**| yes
| **New feature**    | yno
| **Target version** | 4.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
