### PR TITLE
Fixed a translations extraction

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -159,7 +159,7 @@ class Configuration extends SiteAccessConfiguration
                         ->end()
                     ->end()
                 ->end()
-            ;
+        ;
     }
 
     /**
@@ -211,7 +211,7 @@ class Configuration extends SiteAccessConfiguration
                         ->end()
                     ->end()
                 ->end()
-            ;
+        ;
     }
 }
 

--- a/src/lib/Configuration/UI/Mapper/CustomTag.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag.php
@@ -189,9 +189,15 @@ final class CustomTag implements CustomTemplateConfigMapper
 
                 if (isset($config[$tagName]['attributes'][$attributeName]['choicesLabel'])) {
                     foreach ($config[$tagName]['attributes'][$attributeName]['choicesLabel'] as $choice => $label) {
-                        $translatedLabel = $transCatalogue->has($label, $this->translationDomain)
-                            ? $this->translator->trans($label, [], $this->translationDomain)
-                            : $choice;
+                        $translatedLabel = $choice;
+                        if ($transCatalogue->has($label, $this->translationDomain)) {
+                            $translatedLabel = $this->translator->trans(
+                                /** @Ignore */
+                                $label,
+                                [],
+                                $this->translationDomain
+                            );
+                        }
 
                         $config[$tagName]['attributes'][$attributeName]['choicesLabel'][$choice] = $translatedLabel;
                     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | -
| **Target version** | `4.2.0`
| **BC breaks**      | -
| **Tests pass**     | yes
| **Doc needed**     | no

Fixed not working translations extraction due to 

```
Can only extract the translation id from a scalar string, but got "PhpParser\Node\Expr\Variable". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in /home/awojs/ibexa/ibexa-4.2-for-trans-extra/vendor/ibexa/fieldtype-richtext/src/bundle/DependencyInjection/../../../src/lib/Configuration/UI/Mapper/CustomTag.php on line 193).
```

error.

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] ~Implement tests.~
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
