### PR TITLE
[CI] Removed hardcoded Solr version and switched to one relying on branch-alias

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,7 +199,9 @@ jobs:
                   coverage: none
             
             - name: Add solr dependency
-              run: composer require --no-update "ibexa/solr:~4.2.0@dev"
+              run: |
+                VERSION=$(cat composer.json | jq -r '.extra | ."branch-alias" | ."dev-main"')
+                composer require --no-update "ibexa/solr:$VERSION"
 
             - uses: "ramsey/composer-install@v1"
               with:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| CI improvement
| **New feature**    | no
| **Target version** | 4.2, 4.3 and future versions
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

I've removed the hardcoded version from CI and switched to relying on branch-alias - it gets updated with every stable branch, so we won't have to change this additional place with every release.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
