### PR TITLE
IBX-3973: Nontranslatable and disabled fields are not greyed out in content editing UI

### DIFF
--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -202,6 +202,20 @@
     }
 }
 
+.ibexa-field-edit--ezrichtext.ibexa-field-edit--nontranslatable .ibexa-data-source {
+    .ibexa-data-source__richtext {
+        color: $ibexa-color-dark-300;
+        background-color: $ibexa-color-light-300;
+        pointer-events: none;
+    }
+
+    .ibexa-richtext-tools {
+        color: $ibexa-color-dark-400;
+        background-color: $ibexa-color-light-400;
+        pointer-events: none;
+    }
+}
+
 .ck {
     &.ck-editor__editable_inline {
         border: none;

--- a/src/bundle/Resources/public/scss/variables/colors.scss
+++ b/src/bundle/Resources/public/scss/variables/colors.scss
@@ -6,11 +6,14 @@ $ibexa-color-primary: #ae1164 !default;
 $ibexa-color-primary-200: #eecfe0 !default;
 
 $ibexa-color-light: #e0e0e8 !default;
+$ibexa-color-light-400: #ececf1 !default;
+$ibexa-color-light-300: #f3f3f6 !default;
 $ibexa-color-light-300: #f3f3f6 !default;
 $ibexa-color-light-100: #fbfbfc !default;
 
 $ibexa-color-dark: #131c26 !default;
 $ibexa-color-dark-400: #71767c !default;
+$ibexa-color-dark-300: #a0a4a8 !default;
 $ibexa-color-dark-200: #cfd1d3 !default;
 
 $ibexa-color-danger: #db0032 !default;

--- a/src/bundle/Resources/public/scss/variables/colors.scss
+++ b/src/bundle/Resources/public/scss/variables/colors.scss
@@ -8,7 +8,6 @@ $ibexa-color-primary-200: #eecfe0 !default;
 $ibexa-color-light: #e0e0e8 !default;
 $ibexa-color-light-400: #ececf1 !default;
 $ibexa-color-light-300: #f3f3f6 !default;
-$ibexa-color-light-300: #f3f3f6 !default;
 $ibexa-color-light-100: #fbfbfc !default;
 
 $ibexa-color-dark: #131c26 !default;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-3973
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `main`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->

- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
