### PR TITLE
Support adding CKEditor additional plugin configuration

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
+++ b/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
@@ -119,7 +119,7 @@ const VIEWPORT_TOP_OFFSET = 102;
         init(container) {
             const wrapper = this.getHTMLDocumentFragment(container.closest('.ibexa-data-source').querySelector('textarea').value);
             const section = wrapper.childNodes[0];
-            const { toolbar, extraPlugins = [] } = window.ibexa.richText.CKEditor;
+            const { extraOptions, toolbar, extraPlugins = [] } = window.ibexa.richText.CKEditor;
             const blockCustomStyles = Object.entries(ibexa.richText.customStyles)
                 .filter(([, customStyleConfig]) => !customStyleConfig.inline)
                 .map(([customStyleName, customStyleConfig]) => {
@@ -205,6 +205,7 @@ const VIEWPORT_TOP_OFFSET = 102;
                 table: {
                     contentToolbar: ['tableColumn', 'tableRow', 'mergeTableCells'],
                 },
+                ...extraOptions,
             }).then((editor) => {
                 this.editor = editor;
 


### PR DESCRIPTION
Usage Example:
```
const customOptions = {
    highlight: {
        options: [
            //...
        ]
    }
};

window.ibexa.richText.CKEditor.extraOptions =  customOptions ;
```


**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
