### PR TITLE
Use Symfony's router instead of UrlAlias router

### DIFF
--- a/src/bundle/Resources/config/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/fieldtype_services.yaml
@@ -46,7 +46,11 @@ services:
 
     Ibexa\FieldTypeRichText\RichText\Converter\Link:
         class: Ibexa\FieldTypeRichText\RichText\Converter\Link
-        arguments: ['@ibexa.api.service.location', '@ibexa.api.service.content', '@Ibexa\Bundle\Core\Routing\UrlAliasRouter', '@?logger']
+        arguments:
+            - '@ibexa.api.service.location'
+            - '@ibexa.api.service.content'
+            - '@router'
+            - '@?logger'
         tags:
             - {name: ibexa.field_type.richtext.converter.output.xhtml5, priority: 0}
 

--- a/src/lib/RichText/Converter/Link.php
+++ b/src/lib/RichText/Converter/Link.php
@@ -18,6 +18,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\FieldTypeRichText\RichText\Converter;
 use Ibexa\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class Link implements Converter
 {
@@ -32,20 +33,24 @@ class Link implements Converter
     protected $contentService;
 
     /**
-     * @var \Ibexa\Core\MVC\Symfony\Routing\UrlAliasRouter
+     * @var \Symfony\Component\Routing\RouterInterface
      */
-    protected $urlAliasRouter;
+    protected $router;
 
     /**
      * @var \Psr\Log\LoggerInterface
      */
     protected $logger;
 
-    public function __construct(LocationService $locationService, ContentService $contentService, UrlAliasRouter $urlAliasRouter, LoggerInterface $logger = null)
-    {
+    public function __construct(
+        LocationService $locationService,
+        ContentService $contentService,
+        RouterInterface $router,
+        LoggerInterface $logger = null
+    ) {
         $this->locationService = $locationService;
         $this->contentService = $contentService;
-        $this->urlAliasRouter = $urlAliasRouter;
+        $this->router = $router;
         $this->logger = $logger;
     }
 
@@ -137,7 +142,7 @@ class Link implements Converter
 
     private function generateUrlAliasForLocation(Location $location, string $fragment): string
     {
-        $urlAlias = $this->urlAliasRouter->generate(
+        $urlAlias = $this->router->generate(
             UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
             ['location' => $location]
         );

--- a/tests/lib/RichText/Converter/LinkTest.php
+++ b/tests/lib/RichText/Converter/LinkTest.php
@@ -19,6 +19,7 @@ use Ibexa\Core\Repository\LocationService;
 use Ibexa\FieldTypeRichText\RichText\Converter\Link;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Tests the Link converter
@@ -45,9 +46,9 @@ class LinkTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getMockUrlAliasRouter()
+    protected function getMockRouter()
     {
-        return $this->createMock(UrlAliasRouter::class);
+        return $this->createMock(RouterInterface::class);
     }
 
     /**
@@ -119,7 +120,7 @@ class LinkTest extends TestCase
 
         $contentService = $this->getMockContentService();
         $locationService = $this->getMockLocationService();
-        $urlAliasRouter = $this->getMockUrlAliasRouter();
+        $router = $this->getMockRouter();
 
         $contentService->expects($this->never())
             ->method($this->anything());
@@ -127,10 +128,10 @@ class LinkTest extends TestCase
         $locationService->expects($this->never())
             ->method($this->anything());
 
-        $urlAliasRouter->expects($this->never())
+        $router->expects($this->never())
             ->method($this->anything());
 
-        $converter = new Link($locationService, $contentService, $urlAliasRouter);
+        $converter = new Link($locationService, $contentService, $router);
 
         $outputDocument = $converter->convert($inputDocument);
 
@@ -215,7 +216,7 @@ class LinkTest extends TestCase
 
         $contentService = $this->getMockContentService();
         $locationService = $this->getMockLocationService();
-        $urlAliasRouter = $this->getMockUrlAliasRouter();
+        $router = $this->getMockRouter();
 
         $location = $this->createMock(APILocation::class);
 
@@ -224,12 +225,12 @@ class LinkTest extends TestCase
             ->with($this->equalTo($locationId))
             ->willReturn($location);
 
-        $urlAliasRouter->expects($this->once())
+        $router->expects($this->once())
             ->method('generate')
             ->with(UrlAliasRouter::URL_ALIAS_ROUTE_NAME, ['location' => $location])
             ->willReturn($urlResolved);
 
-        $converter = new Link($locationService, $contentService, $urlAliasRouter);
+        $converter = new Link($locationService, $contentService, $router);
 
         $outputDocument = $converter->convert($inputDocument);
 
@@ -320,7 +321,7 @@ class LinkTest extends TestCase
 
         $contentService = $this->getMockContentService();
         $locationService = $this->getMockLocationService();
-        $urlAliasRouter = $this->getMockUrlAliasRouter();
+        $router = $this->getMockRouter();
 
         $logger = $this->createMock(LoggerInterface::class);
 
@@ -333,7 +334,7 @@ class LinkTest extends TestCase
             ->with($this->equalTo($locationId))
             ->will($this->throwException($exception));
 
-        $converter = new Link($locationService, $contentService, $urlAliasRouter, $logger);
+        $converter = new Link($locationService, $contentService, $router, $logger);
 
         $outputDocument = $converter->convert($inputDocument);
 
@@ -419,7 +420,7 @@ class LinkTest extends TestCase
 
         $contentService = $this->getMockContentService();
         $locationService = $this->getMockLocationService();
-        $urlAliasRouter = $this->getMockUrlAliasRouter();
+        $router = $this->getMockRouter();
 
         $contentInfo = $this->createMock(APIContentInfo::class);
         $location = $this->createMock(APILocation::class);
@@ -439,12 +440,12 @@ class LinkTest extends TestCase
             ->with($this->equalTo($locationId))
             ->willReturn($location);
 
-        $urlAliasRouter->expects($this->once())
+        $router->expects($this->once())
             ->method('generate')
             ->with(UrlAliasRouter::URL_ALIAS_ROUTE_NAME, ['location' => $location])
             ->willReturn($urlResolved);
 
-        $converter = new Link($locationService, $contentService, $urlAliasRouter);
+        $converter = new Link($locationService, $contentService, $router);
 
         $outputDocument = $converter->convert($inputDocument);
 
@@ -535,7 +536,7 @@ class LinkTest extends TestCase
 
         $contentService = $this->getMockContentService();
         $locationService = $this->getMockLocationService();
-        $urlAliasRouter = $this->getMockUrlAliasRouter();
+        $router = $this->getMockRouter();
 
         $logger = $this->createMock(LoggerInterface::class);
 
@@ -548,7 +549,7 @@ class LinkTest extends TestCase
             ->with($this->equalTo($contentId))
             ->will($this->throwException($exception));
 
-        $converter = new Link($locationService, $contentService, $urlAliasRouter, $logger);
+        $converter = new Link($locationService, $contentService, $router, $logger);
 
         $outputDocument = $converter->convert($inputDocument);
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `main`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Using `UrlAliasRouter` directly prevents from using the chain routing mechanism and implementing a custom router in a clean way.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
