### PR TITLE
IBX-3988:  RichText formatting options not stored for Numbered List and Bulleted List

### DIFF
--- a/src/bundle/Resources/richtext/schemas/docbook/ezpublish.rng
+++ b/src/bundle/Resources/richtext/schemas/docbook/ezpublish.rng
@@ -75,6 +75,19 @@
         </oneOrMore>
       </element>
     </define>
+    <define name="db.itemizedlist.mark.attribute">
+      <attribute name="mark">
+        <a:documentation>Identifies the type of mark to be used on items in this list</a:documentation>
+        <choice>
+          <value>disc</value>
+          <a:documentation>Items in  the list should be marked using a disc</a:documentation>
+          <value>circle</value>
+          <a:documentation>Items in  the list should be marked using a circle</a:documentation>
+          <value>square</value>
+          <a:documentation>Items in  the list should be marked using a square</a:documentation>
+        </choice>
+      </attribute>
+    </define>
     <define name="db.itemizedlist">
       <element name="itemizedlist">
         <a:documentation>A list in which each entry is marked with a bullet or other dingbat</a:documentation>

--- a/src/bundle/Resources/richtext/schemas/docbook/ezpublish.rng
+++ b/src/bundle/Resources/richtext/schemas/docbook/ezpublish.rng
@@ -62,6 +62,23 @@
       </zeroOrMore>
     </define>
 
+    <!-- Adding 'arabicleadingzero' to db.orderedlist.numeration.enumeration as this is exposed in editor from Ibexa DXP 4.0 -->
+    <define name="db.orderedlist.numeration.enumeration">
+      <choice>
+        <value>arabic</value>
+        <a:documentation>Specifies Arabic numeration (1, 2, 3, …)</a:documentation>
+        <value>arabicleadingzero</value>
+        <a:documentation>Specifies Arabic numeration with leading zero(01, 02, 03, …)</a:documentation>
+        <value>upperalpha</value>
+        <a:documentation>Specifies upper-case alphabetic numeration (A, B, C, …)</a:documentation>
+        <value>loweralpha</value>
+        <a:documentation>Specifies lower-case alphabetic numeration (a, b, c, …)</a:documentation>
+        <value>upperroman</value>
+        <a:documentation>Specifies upper-case Roman numeration (I, II, III, …)</a:documentation>
+        <value>lowerroman</value>
+        <a:documentation>Specifies lower-case Roman numeration (i, ii, iii …)</a:documentation>
+      </choice>
+    </define>
     <define name="db.orderedlist">
       <element name="orderedlist">
         <a:documentation>A list in which each entry is marked with a sequentially incremented label</a:documentation>
@@ -74,19 +91,6 @@
           <ref name="db.listitem"/>
         </oneOrMore>
       </element>
-    </define>
-    <define name="db.itemizedlist.mark.attribute">
-      <attribute name="mark">
-        <a:documentation>Identifies the type of mark to be used on items in this list</a:documentation>
-        <choice>
-          <value>disc</value>
-          <a:documentation>Items in  the list should be marked using a disc</a:documentation>
-          <value>circle</value>
-          <a:documentation>Items in  the list should be marked using a circle</a:documentation>
-          <value>square</value>
-          <a:documentation>Items in  the list should be marked using a square</a:documentation>
-        </choice>
-      </attribute>
     </define>
     <define name="db.itemizedlist">
       <element name="itemizedlist">

--- a/src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -334,6 +334,9 @@
           <xsl:value-of select="@ezxhtml:class"/>
         </xsl:attribute>
       </xsl:if>
+      <xsl:if test="@mark = 'disc'"><xsl:attribute name="style">list-style-type:disc;</xsl:attribute></xsl:if>
+      <xsl:if test="@mark = 'circle'"><xsl:attribute name="style">list-style-type:circle;</xsl:attribute></xsl:if>
+      <xsl:if test="@mark = 'square'"><xsl:attribute name="style">list-style-type:square;</xsl:attribute></xsl:if>
       <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
     </xsl:element>

--- a/src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -317,6 +317,12 @@
           <xsl:value-of select="@ezxhtml:class"/>
         </xsl:attribute>
       </xsl:if>
+      <xsl:if test="@numeration = 'arabic'"><xsl:attribute name="style">list-style-type:decimal;</xsl:attribute></xsl:if>
+      <xsl:if test="@numeration = 'arabicleadingzero'"><xsl:attribute name="style">list-style-type:decimal-leading-zero;</xsl:attribute></xsl:if>
+      <xsl:if test="@numeration = 'lowerroman'"><xsl:attribute name="style">list-style-type:lower-roman;</xsl:attribute></xsl:if>
+      <xsl:if test="@numeration = 'upperroman'"><xsl:attribute name="style">list-style-type:upper-roman;</xsl:attribute></xsl:if>
+      <xsl:if test="@numeration = 'loweralpha'"><xsl:attribute name="style">list-style-type:lower-latin;</xsl:attribute></xsl:if>
+      <xsl:if test="@numeration = 'upperalpha'"><xsl:attribute name="style">list-style-type:upper-latin;</xsl:attribute></xsl:if>
       <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
     </xsl:element>
@@ -334,9 +340,11 @@
           <xsl:value-of select="@ezxhtml:class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:if test="@mark = 'disc'"><xsl:attribute name="style">list-style-type:disc;</xsl:attribute></xsl:if>
-      <xsl:if test="@mark = 'circle'"><xsl:attribute name="style">list-style-type:circle;</xsl:attribute></xsl:if>
-      <xsl:if test="@mark = 'square'"><xsl:attribute name="style">list-style-type:square;</xsl:attribute></xsl:if>
+      <xsl:if test="@mark">
+        <xsl:attribute name="style">
+          <xsl:value-of select="concat('list-style-type:', @mark, ';')"/>
+        </xsl:attribute>
+      </xsl:if>
       <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
     </xsl:element>

--- a/src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/output/core.xsl
@@ -342,6 +342,9 @@
           <xsl:value-of select="@ezxhtml:class"/>
         </xsl:attribute>
       </xsl:if>
+      <xsl:if test="@mark = 'disc'"><xsl:attribute name="style">list-style-type:disc;</xsl:attribute></xsl:if>
+      <xsl:if test="@mark = 'circle'"><xsl:attribute name="style">list-style-type:circle;</xsl:attribute></xsl:if>
+      <xsl:if test="@mark = 'square'"><xsl:attribute name="style">list-style-type:square;</xsl:attribute></xsl:if>
       <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
     </xsl:element>

--- a/src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/output/core.xsl
@@ -325,6 +325,12 @@
           <xsl:value-of select="@ezxhtml:class"/>
         </xsl:attribute>
       </xsl:if>
+      <xsl:if test="@numeration = 'arabic'"><xsl:attribute name="style">list-style-type:decimal;</xsl:attribute></xsl:if>
+      <xsl:if test="@numeration = 'arabicleadingzero'"><xsl:attribute name="style">list-style-type:decimal-leading-zero;</xsl:attribute></xsl:if>
+      <xsl:if test="@numeration = 'lowerroman'"><xsl:attribute name="style">list-style-type:lower-roman;</xsl:attribute></xsl:if>
+      <xsl:if test="@numeration = 'upperroman'"><xsl:attribute name="style">list-style-type:upper-roman;</xsl:attribute></xsl:if>
+      <xsl:if test="@numeration = 'loweralpha'"><xsl:attribute name="style">list-style-type:lower-latin;</xsl:attribute></xsl:if>
+      <xsl:if test="@numeration = 'upperalpha'"><xsl:attribute name="style">list-style-type:upper-latin;</xsl:attribute></xsl:if>
       <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
     </xsl:element>
@@ -342,9 +348,11 @@
           <xsl:value-of select="@ezxhtml:class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:if test="@mark = 'disc'"><xsl:attribute name="style">list-style-type:disc;</xsl:attribute></xsl:if>
-      <xsl:if test="@mark = 'circle'"><xsl:attribute name="style">list-style-type:circle;</xsl:attribute></xsl:if>
-      <xsl:if test="@mark = 'square'"><xsl:attribute name="style">list-style-type:square;</xsl:attribute></xsl:if>
+      <xsl:if test="@mark">
+        <xsl:attribute name="style">
+          <xsl:value-of select="concat('list-style-type:', @mark, ';')"/>
+        </xsl:attribute>
+      </xsl:if>
       <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
     </xsl:element>

--- a/src/bundle/Resources/richtext/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/bundle/Resources/richtext/stylesheets/xhtml5/edit/docbook.xsl
@@ -361,6 +361,13 @@
           <xsl:value-of select="@class"/>
         </xsl:attribute>
       </xsl:if>
+      <xsl:if test="@style">
+        <xsl:attribute name="mark">
+          <xsl:if test="@style = 'list-style-type:disc;'">disc</xsl:if>
+          <xsl:if test="@style = 'list-style-type:circle;'">circle</xsl:if>
+          <xsl:if test="@style = 'list-style-type:square;'">square</xsl:if>
+        </xsl:attribute>
+      </xsl:if>
       <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
     </itemizedlist>

--- a/src/bundle/Resources/richtext/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/bundle/Resources/richtext/stylesheets/xhtml5/edit/docbook.xsl
@@ -344,6 +344,16 @@
           <xsl:value-of select="@class"/>
         </xsl:attribute>
       </xsl:if>
+      <xsl:if test="@style">
+        <xsl:attribute name="numeration">
+          <xsl:if test="@style = 'list-style-type:decimal;'">arabic</xsl:if>
+          <xsl:if test="@style = 'list-style-type:decimal-leading-zero;'">arabicleadingzero</xsl:if>
+          <xsl:if test="@style = 'list-style-type:lower-roman;'">lowerroman</xsl:if>
+          <xsl:if test="@style = 'list-style-type:upper-roman;'">upperroman</xsl:if>
+          <xsl:if test="@style = 'list-style-type:lower-latin;'">loweralpha</xsl:if>
+          <xsl:if test="@style = 'list-style-type:upper-latin;'">upperalpha</xsl:if>
+        </xsl:attribute>
+      </xsl:if>
       <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
     </orderedlist>
@@ -361,11 +371,12 @@
           <xsl:value-of select="@class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:if test="@style">
+      <xsl:if test="contains( @style, 'list-style-type:' )">
         <xsl:attribute name="mark">
-          <xsl:if test="@style = 'list-style-type:disc;'">disc</xsl:if>
-          <xsl:if test="@style = 'list-style-type:circle;'">circle</xsl:if>
-          <xsl:if test="@style = 'list-style-type:square;'">square</xsl:if>
+          <xsl:call-template name="extractStyleValue">
+            <xsl:with-param name="style" select="@style"/>
+            <xsl:with-param name="property" select="'list-style-type'"/>
+          </xsl:call-template>
         </xsl:attribute>
       </xsl:if>
       <xsl:call-template name="ezattribute"/>

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/docbook/036-itemizedListFormatted.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/docbook/036-itemizedListFormatted.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ibexa.co/xmlns/dxp/docbook/xhtml"
+         xmlns:ezcustom="http://ibexa.co/xmlns/dxp/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <itemizedlist mark="disc">
+    <ezattribute>
+      <ezvalue key="name-1">value 1</ezvalue>
+      <ezvalue key="name-2">value 2</ezvalue>
+      <ezvalue key="name-3">value 3</ezvalue>
+    </ezattribute>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-2">value 2</ezvalue>
+      </ezattribute>
+      <para ezxhtml:class="listItemClass">
+        <ezattribute>
+          <ezvalue key="name-2">value 2</ezvalue>
+        </ezattribute>This is a list item.</para>
+    </listitem>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-3">value 3</ezvalue>
+      </ezattribute>
+      <para ezxhtml:class="listItemClass">
+        <ezattribute>
+          <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <literallayout class="normal">This is a list item
+with a line break.</literallayout>
+      </para>
+    </listitem>
+  </itemizedlist>
+  <itemizedlist mark="circle">
+    <ezattribute>
+      <ezvalue key="name-1">value 1</ezvalue>
+      <ezvalue key="name-2">value 2</ezvalue>
+      <ezvalue key="name-3">value 3</ezvalue>
+    </ezattribute>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-2">value 2</ezvalue>
+      </ezattribute>
+      <para ezxhtml:class="listItemClass">
+        <ezattribute>
+          <ezvalue key="name-2">value 2</ezvalue>
+        </ezattribute>This is a list item.</para>
+    </listitem>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-3">value 3</ezvalue>
+      </ezattribute>
+      <para ezxhtml:class="listItemClass">
+        <ezattribute>
+          <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <literallayout class="normal">This is a list item
+with a line break.</literallayout>
+      </para>
+    </listitem>
+  </itemizedlist>
+  <itemizedlist mark="square">
+    <ezattribute>
+      <ezvalue key="name-1">value 1</ezvalue>
+      <ezvalue key="name-2">value 2</ezvalue>
+      <ezvalue key="name-3">value 3</ezvalue>
+    </ezattribute>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-2">value 2</ezvalue>
+      </ezattribute>
+      <para ezxhtml:class="listItemClass"><ezattribute><ezvalue key="name-2">value 2</ezvalue></ezattribute>This is a list item.</para>
+    </listitem>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-3">value 3</ezvalue>
+      </ezattribute>
+      <para ezxhtml:class="listItemClass">
+        <ezattribute>
+          <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <literallayout class="normal">This is a list item
+with a line break.</literallayout>
+      </para>
+    </listitem>
+  </itemizedlist>
+</section>

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/docbook/037-orderedListFormatted.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/docbook/037-orderedListFormatted.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ibexa.co/xmlns/dxp/docbook/xhtml"
+         xmlns:ezcustom="http://ibexa.co/xmlns/dxp/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <para>default</para>
+  <orderedlist>
+    <listitem>
+      <para>default 1</para>
+    </listitem>
+    <listitem>
+      <para>default 2</para>
+    </listitem>
+  </orderedlist>
+  <para>decimal</para>
+  <orderedlist numeration="arabic">
+    <listitem>
+      <para>decimal 1</para>
+    </listitem>
+    <listitem>
+      <para>decimal 2</para>
+    </listitem>
+  </orderedlist>
+  <para>decimal leading zero</para>
+  <orderedlist numeration="arabicleadingzero">
+    <listitem>
+      <para>decimal leading zero 1</para>
+    </listitem>
+    <listitem>
+      <para>decimal leading zero 2</para>
+    </listitem>
+  </orderedlist>
+  <para>lower roman</para>
+  <orderedlist numeration="lowerroman">
+    <listitem>
+      <para>lower roman 1</para>
+    </listitem>
+    <listitem>
+      <para>lower roman 2</para>
+    </listitem>
+  </orderedlist>
+  <para>upper roman</para>
+  <orderedlist numeration="upperroman">
+    <listitem>
+      <para>upper roman 1</para>
+    </listitem>
+  </orderedlist>
+  <orderedlist>
+    <listitem>
+      <para>upper roman 2</para>
+    </listitem>
+  </orderedlist>
+  <para>lower latin</para>
+  <orderedlist numeration="loweralpha">
+    <listitem>
+      <para>lower latin 1</para>
+    </listitem>
+    <listitem>
+      <para>lower latin 2</para>
+    </listitem>
+  </orderedlist>
+  <para>upper latin</para>
+  <orderedlist numeration="upperalpha">
+    <listitem>
+      <para>upper latin 1</para>
+    </listitem>
+    <listitem>
+      <para>upper latin 2</para>
+     </listitem>
+   </orderedlist>
+</section>

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/edit/036-itemizedListFormatted.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/edit/036-itemizedListFormatted.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ibexa.co/namespaces/ezpublish5/xhtml5/edit">
+  <ul style="list-style-type:disc;" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3">
+    <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item<br/>with a line break.</li>
+  </ul>
+  <ul style="list-style-type:circle;" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3">
+    <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item<br/>with a line break.</li>
+  </ul>
+  <ul style="list-style-type:square;" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3">
+    <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item<br/>with a line break.</li>
+  </ul>
+</section>

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/edit/037-orderedListFormatted.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/edit/037-orderedListFormatted.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ibexa.co/namespaces/ezpublish5/xhtml5/edit">
+    <p>default</p>
+    <ol>
+        <li>default 1</li>
+        <li>default 2</li>
+    </ol>
+    <p>decimal</p>
+    <ol style="list-style-type:decimal;">
+        <li>decimal 1</li>
+        <li>decimal 2</li>
+    </ol>
+    <p>decimal leading zero</p>
+    <ol style="list-style-type:decimal-leading-zero;">
+        <li>decimal leading zero 1</li>
+        <li>decimal leading zero 2</li>
+    </ol>
+    <p>lower roman</p>
+    <ol style="list-style-type:lower-roman;">
+        <li>lower roman 1</li>
+        <li>lower roman 2</li>
+    </ol>
+    <p>upper roman</p>
+    <ol style="list-style-type:upper-roman;">
+        <li>upper roman 1</li>
+    </ol>
+    <ol>
+        <li>upper roman 2</li>
+    </ol>
+    <p>lower latin</p>
+    <ol style="list-style-type:lower-latin;">
+        <li>lower latin 1</li>
+        <li>lower latin 2</li>
+    </ol>
+    <p>upper latin</p>
+    <ol style="list-style-type:upper-latin;">
+        <li>upper latin 1</li>
+        <li>upper latin 2</li>
+    </ol>
+</section>

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/output/036-itemizedListFormatted.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/output/036-itemizedListFormatted.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ibexa.co/namespaces/ezpublish5/xhtml5">
+    <ul style="list-style-type:disc;" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item<br/>with a line break.</li>
+    </ul>
+    <ul style="list-style-type:circle;" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item<br/>with a line break.</li>
+    </ul>
+    <ul style="list-style-type:square;" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item<br/>with a line break.</li>
+    </ul>
+</section>

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/output/037-orderedListFormatted.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/output/037-orderedListFormatted.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ibexa.co/namespaces/ezpublish5/xhtml5">
+    <p>default</p>
+    <ol>
+        <li>default 1</li>
+        <li>default 2</li>
+    </ol>
+    <p>decimal</p>
+    <ol style="list-style-type:decimal;">
+        <li>decimal 1</li>
+        <li>decimal 2</li>
+    </ol>
+    <p>decimal leading zero</p>
+    <ol style="list-style-type:decimal-leading-zero;">
+        <li>decimal leading zero 1</li>
+        <li>decimal leading zero 2</li>
+    </ol>
+    <p>lower roman</p>
+    <ol style="list-style-type:lower-roman;">
+        <li>lower roman 1</li>
+        <li>lower roman 2</li>
+    </ol>
+    <p>upper roman</p>
+    <ol style="list-style-type:upper-roman;">
+        <li>upper roman 1</li>
+    </ol>
+    <ol>
+        <li>upper roman 2</li>
+    </ol>
+    <p>lower latin</p>
+    <ol style="list-style-type:lower-latin;">
+        <li>lower latin 1</li>
+        <li>lower latin 2</li>
+    </ol>
+    <p>upper latin</p>
+    <ol style="list-style-type:upper-latin;">
+        <li>upper latin 1</li>
+        <li>upper latin 2</li>
+    </ol>
+</section>

--- a/tests/lib/RichText/Validator/DocbookTest.php
+++ b/tests/lib/RichText/Validator/DocbookTest.php
@@ -114,6 +114,47 @@ class DocbookTest extends TestCase
 </section>',
                 [],
             ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ibexa.co/xmlns/dxp/docbook/xhtml"
+         xmlns:ezcustom="http://ibexa.co/xmlns/dxp/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <itemizedlist mark="unsupported">
+    <ezattribute>
+      <ezvalue key="name-1">value 1</ezvalue>
+      <ezvalue key="name-2">value 2</ezvalue>
+      <ezvalue key="name-3">value 3</ezvalue>
+    </ezattribute>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-2">value 2</ezvalue>
+      </ezattribute>
+      <para ezxhtml:class="listItemClass">
+        <ezattribute>
+          <ezvalue key="name-2">value 2</ezvalue>
+        </ezattribute>This is a list item.</para>
+    </listitem>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-3">value 3</ezvalue>
+      </ezattribute>
+      <para ezxhtml:class="listItemClass">
+        <ezattribute>
+          <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <literallayout class="normal">This is a list item
+with a line break.</literallayout>
+      </para>
+    </listitem>
+  </itemizedlist>
+</section>
+',
+                [
+                    'Element section has extra content: itemizedlist',
+                ],
+            ],
         ];
     }
 

--- a/tests/lib/RichText/Validator/DocbookTest.php
+++ b/tests/lib/RichText/Validator/DocbookTest.php
@@ -114,47 +114,6 @@ class DocbookTest extends TestCase
 </section>',
                 [],
             ],
-            [
-                '<?xml version="1.0" encoding="UTF-8"?>
-<section xmlns="http://docbook.org/ns/docbook"
-         xmlns:xlink="http://www.w3.org/1999/xlink"
-         xmlns:ezxhtml="http://ibexa.co/xmlns/dxp/docbook/xhtml"
-         xmlns:ezcustom="http://ibexa.co/xmlns/dxp/docbook/custom"
-         version="5.0-variant ezpublish-1.0">
-  <itemizedlist mark="unsupported">
-    <ezattribute>
-      <ezvalue key="name-1">value 1</ezvalue>
-      <ezvalue key="name-2">value 2</ezvalue>
-      <ezvalue key="name-3">value 3</ezvalue>
-    </ezattribute>
-    <listitem ezxhtml:class="listItemClass">
-      <ezattribute>
-        <ezvalue key="name-2">value 2</ezvalue>
-      </ezattribute>
-      <para ezxhtml:class="listItemClass">
-        <ezattribute>
-          <ezvalue key="name-2">value 2</ezvalue>
-        </ezattribute>This is a list item.</para>
-    </listitem>
-    <listitem ezxhtml:class="listItemClass">
-      <ezattribute>
-        <ezvalue key="name-3">value 3</ezvalue>
-      </ezattribute>
-      <para ezxhtml:class="listItemClass">
-        <ezattribute>
-          <ezvalue key="name-3">value 3</ezvalue>
-        </ezattribute>
-        <literallayout class="normal">This is a list item
-with a line break.</literallayout>
-      </para>
-    </listitem>
-  </itemizedlist>
-</section>
-',
-                [
-                    'Element section has extra content: itemizedlist',
-                ],
-            ],
         ];
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-3988](https://issues.ibexa.co/browse/IBX-3988)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | 4.3
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

This PR ensures that styling in lists are stored in docbook

Related DocBook Specs:
https://tdg.docbook.org/tdg/5.0/orderedlist.html
https://tdg.docbook.org/tdg/5.0/itemizedlist.html

**TODO**:
- [x] ~Remove decimal-leading-zero button from Editor - It is not supported by DocBook~ Added support for `decimal-leading-zero` in our schema instead
- [x] Implemented XHTML output conversion
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
