### PR TITLE
fixup! Return attributes node even when none is provided for custom tags

### DIFF
--- a/src/lib/Configuration/UI/Mapper/CustomTag.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag.php
@@ -96,6 +96,7 @@ final class CustomTag implements CustomTemplateConfigMapper
                 'label' => "ezrichtext.custom_tags.{$tagName}.label",
                 'description' => "ezrichtext.custom_tags.{$tagName}.description",
                 'isInline' => $customTagConfiguration['is_inline'],
+                'attributes' => [],
             ];
 
             if (!empty($customTagConfiguration['icon'])) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-XXXXX](https://issues.ibexa.co/browse/IBX-XXXXX)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.3
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

<!-- Replace this comment with Pull Request description -->
With the following configuration
```yaml
ibexa:
    system:
        default:
            fieldtypes:
                ezrichtext:
                    custom_tags: [mytag]
ibexa_fieldtype_richtext:
     custom_tags:
        mytag:
            template: field_type/ibexa_fieldtype_richtext/custom_tags/mytag.html.twig
            icon: '/assets/field_type/ibexa_fieldtype_richtext/custom_tags/icon/mytag.svg'```
```

I have an error in JS because no attribute is defined.

The error occures at least at two places:
- https://github.com/ibexa/fieldtype-richtext/blob/v4.3.1/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-ui.js#L173-L177
- https://github.com/ibexa/fieldtype-richtext/blob/v4.3.1/src/bundle/Resources/public/js/CKEditor/custom-tags/inline-custom-tag/inline-custom-tag-ui.js#L115-L119

It's because `this.config.attributes` is `undefined`.

This change allows us to make sure that `this.config.attributes` is always defined.

see: https://github.com/ibexa/fieldtype-richtext/pull/42#issuecomment-1397366596

**TODO**:
- [X] Fix a bug.
- [ ] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
