### PR TITLE
fixup! Avoid js error when `configElement` is not defined

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
@@ -105,6 +105,10 @@ class IbexaCustomTagEditing extends Plugin {
                 }
 
                 const configElement = viewElement.getChild(1);
+                if (configElement === undefined) {
+                    return;
+                }
+
                 const configValuesIterator = configElement.getChildren();
                 const customTagName = viewElement.getAttribute('data-ezname');
                 const values = {};

--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/inline-custom-tag/inline-custom-tag-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/inline-custom-tag/inline-custom-tag-editing.js
@@ -82,6 +82,10 @@ class IbexaInlineCustomTagEditing extends Plugin {
                 }
 
                 const configElement = viewElement.getChild(1);
+                if (configElement === undefined) {
+                    return;
+                }
+
                 const configValuesIterator = configElement.getChildren();
                 const customTagName = viewElement.getAttribute('data-ezname');
                 const values = {};


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-XXXXX](https://issues.ibexa.co/browse/IBX-XXXXX)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.3
| **BC breaks**      | yes
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

<!-- Replace this comment with Pull Request description -->
When using a legacy `eztemplate` from EzPlatform 2.5, I have an error at this point where `configElement` could be `undefined`.

This check make sure the error does not occures.

**TODO**:
- [X] Fix a bug.
- [ ] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
