### PR TITLE
IBX-4970 changed scss for ibexa-custom-tag-attributes__item-value so long string value won't break edit

### DIFF
--- a/src/bundle/Resources/public/scss/_custom-tag-attributes.scss
+++ b/src/bundle/Resources/public/scss/_custom-tag-attributes.scss
@@ -27,6 +27,8 @@
 
         &__item-value {
             font-size: $ibexa-text-font-size;
+            max-width: 400px;
+            overflow: hidden;
         }
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-4970](https://issues.ibexa.co/browse/IBX-4970)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.3
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

Edit functionality is broken when custom string value is too long.
Added `max-width: 400px;overf low: hidden;` to `ibexthe a-custom-tag-attributes__item-value` class. 


**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
