### PR TITLE
IBX-5054: HTML code gets removed from the Custom tag's string attribute

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
@@ -76,7 +76,12 @@ class IbexaCustomTagEditing extends Plugin {
                     const domElement = this.toDomElement(domDocument);
 
                     domElement.innerHTML = Object.entries(modelElement.getAttribute('values')).reduce((total, [attribute, value]) => {
-                        const attributeValue = value !== null ? value : '';
+                        // Escaping
+                        // <script>alert("Hello! I am a script!");</script> --> &lt;script&gt;alert("Hello! I am a script!");&lt;/script&gt;
+                        const stringTempNode = domDocument.createElement('div');
+                        stringTempNode.appendChild(domDocument.createTextNode(value !== null ? value : ''));
+                        const attributeValue = stringTempNode.innerHTML;
+
                         const ezvalue = `<span data-ezelement="ezvalue" data-ezvalue-key="${attribute}">${attributeValue}</span>`;
 
                         return `${total}${ezvalue}`;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5054](https://issues.ibexa.co/browse/IBX-5054)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.3
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

Missing escaping of input


**TODO**:
- [x] Implement feature / fix a bug.
- [ ] ~Implement tests.~ ( Assume this is not needed for this one ?)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
