### PR TITLE
IBX-5147: [Rich text field type] Closing custom tag before finishing edition causes edition to hover.

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-ui.js
@@ -169,6 +169,10 @@ class IbexaCustomTagUI extends Plugin {
 
         this.editor.model.change((writer) => {
             writer.remove(modelElement);
+
+            if (this.balloon.hasView(this.attributesView)) {
+                this.hideAttributes();
+            }
         });
     }
 

--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-ui.js
@@ -168,11 +168,11 @@ class IbexaCustomTagUI extends Plugin {
         const modelElement = this.editor.model.document.selection.getSelectedElement();
 
         this.editor.model.change((writer) => {
-            writer.remove(modelElement);
-
             if (this.balloon.hasView(this.attributesView)) {
                 this.hideAttributes();
             }
+
+            writer.remove(modelElement);
         });
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-5147
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.3
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
