### PR TITLE
IBX-4927: Changing custom tag configuration breaks existing Rich Text fields that include this tag

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
+++ b/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
@@ -207,13 +207,20 @@ const VIEWPORT_TOP_OFFSET = 102;
                 },
             }).then((editor) => {
                 this.editor = editor;
-
-                this.editor.model.document.on('change:data', () => {
-                    const data = this.getData();
+                const initialData = this.getData();
+                const updateInput = (data) => {
                     const textarea = container.closest('.ibexa-data-source').querySelector('textarea');
 
                     textarea.value = this.xhtmlify(data).replace(this.xhtmlNamespace, this.ezNamespace);
                     textarea.dispatchEvent(new Event('input'));
+                }
+
+                updateInput(initialData);
+
+                this.editor.model.document.on('change:data', () => {
+                    const data = this.getData();
+
+                    updateInput(data);
                 });
             });
         }

--- a/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
+++ b/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
@@ -213,7 +213,7 @@ const VIEWPORT_TOP_OFFSET = 102;
 
                     textarea.value = this.xhtmlify(data).replace(this.xhtmlNamespace, this.ezNamespace);
                     textarea.dispatchEvent(new Event('input'));
-                }
+                };
 
                 updateInput(initialData);
 

--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
@@ -26,6 +26,7 @@ class IbexaCustomTagEditing extends Plugin {
     }
 
     defineConverters() {
+        const { customTags } = window.ibexa.richText;
         const { conversion } = this.editor;
 
         conversion.for('editingDowncast').elementToElement({
@@ -112,9 +113,16 @@ class IbexaCustomTagEditing extends Plugin {
                 const configElement = viewElement.getChild(1);
                 const configValuesIterator = configElement.getChildren();
                 const customTagName = viewElement.getAttribute('data-ezname');
+                const tagConfig = customTags[customTagName];
                 const values = {};
 
                 for (const configValue of configValuesIterator) {
+                    const configName = configValue.getAttribute('data-ezvalue-key');
+
+                    if (!tagConfig?.attributes?.hasOwnProperty(configName)) {
+                        continue;
+                    }
+
                     const value = (configValue.getChild(0) && configValue.getChild(0).data) || null;
 
                     values[configValue.getAttribute('data-ezvalue-key')] = value;

--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
@@ -113,13 +113,14 @@ class IbexaCustomTagEditing extends Plugin {
                 const configElement = viewElement.getChild(1);
                 const configValuesIterator = configElement.getChildren();
                 const customTagName = viewElement.getAttribute('data-ezname');
-                const tagConfig = customTags[customTagName];
+                const tagConfig = customTags[customTagName] ?? {};
                 const values = {};
 
                 for (const configValue of configValuesIterator) {
                     const configName = configValue.getAttribute('data-ezvalue-key');
+                    const configAttributes = tagConfig.attributes ?? {};
 
-                    if (!tagConfig?.attributes?.hasOwnProperty(configName)) {
+                    if (!Object.prototype.hasOwnProperty.call(configAttributes, configName)) {
                         continue;
                     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-4927
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.3
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
