### PR TITLE
IBX-5376: Added possibility to change config of CKE

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
+++ b/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
@@ -119,7 +119,7 @@ const VIEWPORT_TOP_OFFSET = 102;
         init(container) {
             const wrapper = this.getHTMLDocumentFragment(container.closest('.ibexa-data-source').querySelector('textarea').value);
             const section = wrapper.childNodes[0];
-            const { toolbar, extraPlugins = [] } = window.ibexa.richText.CKEditor;
+            const { toolbar, extraPlugins = [], extraConfig = {} } = window.ibexa.richText.CKEditor;
             const locale = new Intl.Locale(doc.querySelector('meta[name="LanguageCode"]').content);
             const blockCustomStyles = Object.entries(ibexa.richText.customStyles)
                 .filter(([, customStyleConfig]) => !customStyleConfig.inline)
@@ -209,6 +209,7 @@ const VIEWPORT_TOP_OFFSET = 102;
                 language: {
                     content: locale.language,
                 },
+                ...extraConfig,
             }).then((editor) => {
                 this.editor = editor;
                 const initialData = this.getData();

--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -186,7 +186,7 @@
         min-height: calculateRem(20px);
     }
 
-    [id] {
+    [id]:not(.ibexa-data-source__richtext) {
         position: relative;
 
         &:before {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-5376
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.4
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

<!-- Replace this comment with Pull Request description -->

For QA:
To test it you can change the language of the content in CKE
paste this code into line 84 in layout.html.twig in admin-ui

`window.ibexa.addConfig('richText.CKEditor.extraConfig', { language: { content: 'ar' }}, true);`

Doc:
In order to add or override config the custom config object should be added to the `window.ibexa.richText.CKEditor.extraConfig` key. The easiest way is to use `addConfig` method for example:
`window.ibexa.addConfig('richText.CKEditor.extraConfig', {{your_custom_config_object}}, true);`
CKEditor config doc: https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editorconfig-EditorConfig.html

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
