### PR TITLE
IBX-4911: Fixed breaking custom styles by italic or strikethrough

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/custom-styles/inline/custom-style-inline-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-styles/inline/custom-style-inline-editing.js
@@ -19,21 +19,29 @@ class IbexaCustomStyleInlineEditing extends Plugin {
         this.editor.conversion.for('editingDowncast').attributeToElement({
             model: this.customStyleName,
             view: (customStyleValue, { writer: downcastWriter }) =>
-                downcastWriter.createAttributeElement('span', {
-                    'data-ezelement': 'eztemplateinline',
-                    'data-eztype': 'style',
-                    'data-ezname': this.customStyleName,
-                }),
+                downcastWriter.createAttributeElement(
+                    'span',
+                    {
+                        'data-ezelement': 'eztemplateinline',
+                        'data-eztype': 'style',
+                        'data-ezname': this.customStyleName,
+                    },
+                    { priority: 5 },
+                ),
         });
 
         this.editor.conversion.for('dataDowncast').attributeToElement({
             model: this.customStyleName,
             view: (customStyleValue, { writer: downcastWriter }) =>
-                downcastWriter.createAttributeElement('span', {
-                    'data-ezelement': 'eztemplateinline',
-                    'data-eztype': 'style',
-                    'data-ezname': this.customStyleName,
-                }),
+                downcastWriter.createAttributeElement(
+                    'span',
+                    {
+                        'data-ezelement': 'eztemplateinline',
+                        'data-eztype': 'style',
+                        'data-ezname': this.customStyleName,
+                    },
+                    { priority: 5 },
+                ),
         });
 
         this.editor.conversion.for('upcast').elementToAttribute({


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-4911
| **Bug/Improvement**| yes
| **New feature**    | o
| **Target version** | v4.4
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->
**Note for QA**
Strikethrough has the same problem, this PR solves problem in both.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
