### PR TITLE
IBX-5788: Fixed the `upcast` conversion in image editing

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
@@ -170,7 +170,7 @@ class IbexaEmbedImageEditing extends Plugin {
                 const link = viewElement.getChild(1);
                 const modelElement = upcastWriter.createElement('embedImage', { contentId, size });
 
-                if (link) {
+                if (link instanceof Element) {
                     upcastWriter.setAttribute('ibexaLinkHref', link.getAttribute('href'), modelElement);
                     upcastWriter.setAttribute('ibexaLinkTitle', link.getAttribute('title') ?? '', modelElement);
                     upcastWriter.setAttribute('ibexaLinkTarget', link.getAttribute('target') ?? '', modelElement);

--- a/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
@@ -170,7 +170,7 @@ class IbexaEmbedImageEditing extends Plugin {
                 const link = viewElement.getChild(1);
                 const modelElement = upcastWriter.createElement('embedImage', { contentId, size });
 
-                if (link instanceof Element) {
+                if (link?.is('element', 'a')) {
                     upcastWriter.setAttribute('ibexaLinkHref', link.getAttribute('href'), modelElement);
                     upcastWriter.setAttribute('ibexaLinkTitle', link.getAttribute('title') ?? '', modelElement);
                     upcastWriter.setAttribute('ibexaLinkTarget', link.getAttribute('target') ?? '', modelElement);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5788](https://issues.ibexa.co/browse/IBX-5788)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `4.4`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

`link` wasn't a proper DOM element in case of copying and pasting.

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
