### PR TITLE
IBX-5757: Fixed custom classes and attributes on headings

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-command.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-command.js
@@ -1,6 +1,6 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
-import { getCustomAttributesConfig } from './helpers/custom-attributes-config-helper';
+import { getCustomAttributesConfig, getCustomClassesConfig } from './helpers/config-helper';
 
 class IbexaCustomAttributesCommand extends Command {
     cleanAttributes(modelElement, attributes) {
@@ -36,7 +36,8 @@ class IbexaCustomAttributesCommand extends Command {
     refresh() {
         const { selection } = this.editor.model.document;
         const parentElement = selection.getSelectedElement() ?? selection.getFirstPosition().parent;
-        const { attributes, classes } = getCustomAttributesConfig();
+        const attributes = getCustomAttributesConfig();
+        const classes = getCustomClassesConfig();
         const parentElementAttributesConfig = attributes[parentElement.name];
         const parentElementClassesConfig = classes[parentElement.name];
         const isEnabled = parentElementAttributesConfig || parentElementClassesConfig;

--- a/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-command.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-command.js
@@ -1,5 +1,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
+import { getCustomAttributesConfig } from './helpers/custom-attributes-config-helper';
+
 class IbexaCustomAttributesCommand extends Command {
     cleanAttributes(modelElement, attributes) {
         Object.entries(attributes).forEach(([elementName, config]) => {
@@ -34,7 +36,7 @@ class IbexaCustomAttributesCommand extends Command {
     refresh() {
         const { selection } = this.editor.model.document;
         const parentElement = selection.getSelectedElement() ?? selection.getFirstPosition().parent;
-        const { attributes, classes } = window.ibexa.richText.alloyEditor;
+        const { attributes, classes } = getCustomAttributesConfig();
         const parentElementAttributesConfig = attributes[parentElement.name];
         const parentElementClassesConfig = classes[parentElement.name];
         const isEnabled = parentElementAttributesConfig || parentElementClassesConfig;

--- a/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-command.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-command.js
@@ -36,16 +36,16 @@ class IbexaCustomAttributesCommand extends Command {
     refresh() {
         const { selection } = this.editor.model.document;
         const parentElement = selection.getSelectedElement() ?? selection.getFirstPosition().parent;
-        const attributes = getCustomAttributesConfig();
-        const classes = getCustomClassesConfig();
-        const parentElementAttributesConfig = attributes[parentElement.name];
-        const parentElementClassesConfig = classes[parentElement.name];
+        const customAttributesConfig = getCustomAttributesConfig();
+        const customClassesConfig = getCustomClassesConfig();
+        const parentElementAttributesConfig = customAttributesConfig[parentElement.name];
+        const parentElementClassesConfig = customClassesConfig[parentElement.name];
         const isEnabled = parentElementAttributesConfig || parentElementClassesConfig;
 
         this.isEnabled = !!isEnabled;
 
-        this.cleanAttributes(parentElement, attributes);
-        this.cleanClasses(parentElement, classes);
+        this.cleanAttributes(parentElement, customAttributesConfig);
+        this.cleanClasses(parentElement, customClassesConfig);
     }
 }
 

--- a/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-editing.js
@@ -2,7 +2,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 
 import IbexaCustomAttributesCommand from './custom-attributes-command';
-import { getCustomAttributesConfig } from './helpers/custom-attributes-config-helper';
+import { getCustomAttributesConfig, getCustomClassesConfig } from './helpers/config-helper';
 
 class IbexaCustomAttributesEditing extends Plugin {
     static get requires() {
@@ -22,7 +22,7 @@ class IbexaCustomAttributesEditing extends Plugin {
             },
         });
 
-        Object.values(customAttributesConfig.attributes).forEach((customAttributes) => {
+        Object.values(customAttributesConfig).forEach((customAttributes) => {
             Object.keys(customAttributes).forEach((customAttributeName) => {
                 conversion.attributeToAttribute({
                     model: {
@@ -47,11 +47,12 @@ class IbexaCustomAttributesEditing extends Plugin {
     init() {
         const { model } = this.editor;
         const customAttributesConfig = getCustomAttributesConfig();
-        const elementsWithCustomAttributes = Object.keys(customAttributesConfig.attributes);
-        const elementsWithCustomClasses = Object.keys(customAttributesConfig.classes);
+        const customClassesConfig = getCustomClassesConfig();
+        const elementsWithCustomAttributes = Object.keys(customAttributesConfig);
+        const elementsWithCustomClasses = Object.keys(customClassesConfig);
 
         elementsWithCustomAttributes.forEach((element) => {
-            const customAttributes = Object.keys(customAttributesConfig.attributes[element]);
+            const customAttributes = Object.keys(customAttributesConfig[element]);
 
             this.extendSchema(model.schema, element, { allowAttributes: customAttributes });
         });

--- a/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-editing.js
@@ -2,6 +2,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 
 import IbexaCustomAttributesCommand from './custom-attributes-command';
+import { getCustomAttributesConfig } from './helpers/custom-attributes-config-helper';
 
 class IbexaCustomAttributesEditing extends Plugin {
     static get requires() {
@@ -10,6 +11,7 @@ class IbexaCustomAttributesEditing extends Plugin {
 
     defineConverters() {
         const { conversion } = this.editor;
+        const customAttributesConfig = getCustomAttributesConfig();
 
         conversion.attributeToAttribute({
             model: {
@@ -20,7 +22,7 @@ class IbexaCustomAttributesEditing extends Plugin {
             },
         });
 
-        Object.values(window.ibexa.richText.alloyEditor.attributes).forEach((customAttributes) => {
+        Object.values(customAttributesConfig.attributes).forEach((customAttributes) => {
             Object.keys(customAttributes).forEach((customAttributeName) => {
                 conversion.attributeToAttribute({
                     model: {
@@ -34,19 +36,28 @@ class IbexaCustomAttributesEditing extends Plugin {
         });
     }
 
+    extendSchema(schema, element, definition) {
+        if (schema.getDefinition(element)) {
+            schema.extend(element, definition);
+        } else {
+            console.warn(`Schema does not have '${element}' element`);
+        }
+    }
+
     init() {
         const { model } = this.editor;
-        const elementsWithCustomAttributes = Object.keys(window.ibexa.richText.alloyEditor.attributes);
-        const elementsWithCustomClasses = Object.keys(window.ibexa.richText.alloyEditor.classes);
+        const customAttributesConfig = getCustomAttributesConfig();
+        const elementsWithCustomAttributes = Object.keys(customAttributesConfig.attributes);
+        const elementsWithCustomClasses = Object.keys(customAttributesConfig.classes);
 
         elementsWithCustomAttributes.forEach((element) => {
-            const customAttributes = Object.keys(window.ibexa.richText.alloyEditor.attributes[element]);
+            const customAttributes = Object.keys(customAttributesConfig.attributes[element]);
 
-            model.schema.extend(element, { allowAttributes: customAttributes });
+            this.extendSchema(model.schema, element, { allowAttributes: customAttributes });
         });
 
         elementsWithCustomClasses.forEach((element) => {
-            model.schema.extend(element, { allowAttributes: 'custom-classes' });
+            this.extendSchema(model.schema, element, { allowAttributes: 'custom-classes' });
         });
 
         this.defineConverters();

--- a/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-ui.js
@@ -4,7 +4,7 @@ import clickOutsideHandler from '@ckeditor/ckeditor5-ui/src/bindings/clickoutsid
 import IbexaCustomAttributesFormView from './ui/custom-attributes-form-view';
 import IbexaButtonView from '../common/button-view/button-view';
 
-import { getCustomAttributesConfig } from './helpers/custom-attributes-config-helper';
+import { getCustomAttributesConfig, getCustomClassesConfig } from './helpers/config-helper';
 
 const { Translator } = window;
 
@@ -62,8 +62,9 @@ class IbexaAttributesUI extends Plugin {
     showForm() {
         const parentElement = this.getModelElement();
         const customAttributesConfig = getCustomAttributesConfig();
-        const customAttributes = customAttributesConfig.attributes[parentElement.name] ?? {};
-        const customClasses = customAttributesConfig.classes[parentElement.name];
+        const customClassesConfig = getCustomClassesConfig();
+        const customAttributes = customAttributesConfig[parentElement.name] ?? {};
+        const customClasses = customClassesConfig[parentElement.name];
         const areCustomAttributesSet =
             parentElement.hasAttribute('custom-classes') ||
             Object.keys(customAttributes).some((customAttributeName) => parentElement.hasAttribute(customAttributeName));

--- a/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-attributes/custom-attributes-ui.js
@@ -4,6 +4,8 @@ import clickOutsideHandler from '@ckeditor/ckeditor5-ui/src/bindings/clickoutsid
 import IbexaCustomAttributesFormView from './ui/custom-attributes-form-view';
 import IbexaButtonView from '../common/button-view/button-view';
 
+import { getCustomAttributesConfig } from './helpers/custom-attributes-config-helper';
+
 const { Translator } = window;
 
 class IbexaAttributesUI extends Plugin {
@@ -59,8 +61,9 @@ class IbexaAttributesUI extends Plugin {
 
     showForm() {
         const parentElement = this.getModelElement();
-        const customAttributes = window.ibexa.richText.alloyEditor.attributes[parentElement.name] ?? {};
-        const customClasses = window.ibexa.richText.alloyEditor.classes[parentElement.name];
+        const customAttributesConfig = getCustomAttributesConfig();
+        const customAttributes = customAttributesConfig.attributes[parentElement.name] ?? {};
+        const customClasses = customAttributesConfig.classes[parentElement.name];
         const areCustomAttributesSet =
             parentElement.hasAttribute('custom-classes') ||
             Object.keys(customAttributes).some((customAttributeName) => parentElement.hasAttribute(customAttributeName));

--- a/src/bundle/Resources/public/js/CKEditor/custom-attributes/helpers/config-helper.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-attributes/helpers/config-helper.js
@@ -2,7 +2,6 @@ const headingsList = ['heading1', 'heading2', 'heading3', 'heading4', 'heading5'
 
 const getCustomAttributesConfig = () => {
     const attributes = { ...window.ibexa.richText.alloyEditor.attributes };
-    const classes = { ...window.ibexa.richText.alloyEditor.classes };
 
     if (Object.hasOwn(attributes, 'heading')) {
         headingsList.forEach((headingType) => {
@@ -16,6 +15,12 @@ const getCustomAttributesConfig = () => {
         delete attributes.heading;
     }
 
+    return attributes;
+};
+
+const getCustomClassesConfig = () => {
+    const classes = { ...window.ibexa.richText.alloyEditor.classes };
+
     if (Object.hasOwn(classes, 'heading')) {
         headingsList.forEach((headingType) => {
             if (Object.hasOwn(classes, headingType)) {
@@ -28,7 +33,7 @@ const getCustomAttributesConfig = () => {
         delete classes.heading;
     }
 
-    return { attributes, classes };
+    return classes;
 };
 
-export { getCustomAttributesConfig };
+export { getCustomAttributesConfig, getCustomClassesConfig };

--- a/src/bundle/Resources/public/js/CKEditor/custom-attributes/helpers/custom-attributes-config-helper.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-attributes/helpers/custom-attributes-config-helper.js
@@ -1,0 +1,34 @@
+const headingsList = ['heading1', 'heading2', 'heading3', 'heading4', 'heading5', 'heading6'];
+
+const getCustomAttributesConfig = () => {
+    const attributes = { ...window.ibexa.richText.alloyEditor.attributes };
+    const classes = { ...window.ibexa.richText.alloyEditor.classes };
+
+    if (Object.hasOwn(attributes, 'heading')) {
+        headingsList.forEach((headingType) => {
+            if (Object.hasOwn(attributes, headingType)) {
+                return;
+            }
+
+            attributes[headingType] = attributes.heading;
+        });
+
+        delete attributes.heading;
+    }
+
+    if (Object.hasOwn(classes, 'heading')) {
+        headingsList.forEach((headingType) => {
+            if (Object.hasOwn(classes, headingType)) {
+                return;
+            }
+
+            classes[headingType] = classes.heading;
+        });
+
+        delete classes.heading;
+    }
+
+    return { attributes, classes };
+};
+
+export { getCustomAttributesConfig };


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-5757
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.4
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

<!-- Replace this comment with Pull Request description -->
For doc:
In doc, we have a list of elements that can have custom attributes and classes: https://doc.ibexa.co/en/latest/content_management/rich_text/extend_online_editor/#configure-custom-data-attributes-and-classes
Now in the configuration we have two options, we can define `heading` and it will work like it was in the previous versions, the custom classes and attributes will be added to every heading. 
The second way is to specify custom attributes and classes to a specific heading: 'heading1', 'heading2', 'heading3', 'heading4', 'heading5', 'heading6'.
The more specific key is more important, which means if there will config for `heading` and `heading2`, the `heading2` will have custom attributes and classes only from the `heading2` config and will not inherit any attributes or classes from the `heading` config.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
