### PR TITLE
IBX-6022: Image variation label

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-variations-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-variations-ui.js
@@ -3,6 +3,8 @@ import { createDropdown, addListToDropdown } from '@ckeditor/ckeditor5-ui/src/dr
 import Model from '@ckeditor/ckeditor5-ui/src/model';
 import Collection from '@ckeditor/ckeditor5-utils/src/collection';
 
+const { Translator } = window;
+
 class IbexaEmbedImageVariationsUI extends Plugin {
     constructor(props) {
         super(props);
@@ -36,7 +38,7 @@ class IbexaEmbedImageVariationsUI extends Plugin {
                 itemDefinitions.add({
                     type: 'button',
                     model: new Model({
-                        label: variation,
+                        label: Translator.trans(variation, {}, 'image_variations'),
                         variation: variation,
                         withText: true,
                     }),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-6022](https://issues.ibexa.co/browse/IBX-6022)
| **Bug/Improvement**| Improvement
| **New feature**    | yes
| **Target version** | main
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Add a way to have user friendly image variation name in the richtext editor

Use the JS translator to translate the image variation identifier into a user friendly label
If there is no translation, the identifier is displayed as previously