### PR TITLE
IBX-6149: Richtext: Anchor is duplicated when entering newline

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/anchor/anchor-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/anchor/anchor-editing.js
@@ -20,13 +20,23 @@ class IbexaAnchorEditing extends Plugin {
     }
 
     init() {
-        const { model } = this.editor;
+        const { commands, model } = this.editor;
 
         model.schema.extend('$block', { allowAttributes: 'anchor' });
         model.schema.extend('embed', { allowAttributes: 'anchor' });
         model.schema.extend('embedInline', { allowAttributes: 'anchor' });
         model.schema.extend('embedImage', { allowAttributes: 'anchor' });
         model.schema.extend('customTag', { allowAttributes: 'anchor' });
+
+        commands.get('enter').on('afterExecute', () => {
+            const blocks = model.document.selection.getSelectedBlocks();
+
+            for (const block of blocks) {
+                model.change((writer) => {
+                    writer.removeAttribute('anchor', block);
+                });
+            }
+        });
 
         this.defineConverters();
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-6149
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
