### PR TITLE
IBX-6077: Custom classes and attributes on table in ReichText Online Editor are not saved

### DIFF
--- a/src/bundle/Resources/config/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/fieldtype_services.yaml
@@ -143,6 +143,12 @@ services:
         tags:
             - {name: ibexa.field_type.richtext.converter.input.xhtml5, priority: 10}
 
+    # Note: should run before xsl transformation
+    Ibexa\FieldTypeRichText\RichText\Converter\Figure:
+        class: Ibexa\FieldTypeRichText\RichText\Converter\Figure
+        tags:
+            - {name: ibexa.field_type.richtext.converter.input.xhtml5, priority: 10}
+
     Ibexa\FieldTypeRichText\RichText\Converter\Html5Edit:
         class: Ibexa\FieldTypeRichText\RichText\Converter\Html5Edit
         arguments:

--- a/src/lib/RichText/Converter/Figure.php
+++ b/src/lib/RichText/Converter/Figure.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\FieldTypeRichText\RichText\Converter;
+
+use DOMDocument;
+use DOMXPath;
+use Ibexa\Contracts\FieldTypeRichText\RichText\Converter;
+
+/**
+ * Class ProgramListing.
+ *
+ * Processes <code>programlisting</code> DocBook tag.
+ */
+class Figure implements Converter
+{
+    /**
+     * CDATA's content cannot contain the sequence ']]>' as that will terminate the CDATA section.
+     * So, if the end sequence ']]>' appears in the string, we split the text into multiple CDATA sections.
+     *
+     * @param \DOMDocument $document
+     *
+     * @return \DOMDocument
+     */
+    public function convert(DOMDocument $document)
+    {
+        $xpath = new DOMXPath($document);
+        $xpathExpression = '//ns:figure [descendant::ns:table]';
+        $ns = $document->documentElement ? $document->documentElement->namespaceURI ?: '' : '';
+        $xpath->registerNamespace('ns', $ns);
+        /** @var \DomNodeList $elements */
+        $elements = $xpath->query($xpathExpression) ?: [];
+
+        // elements are list of <figure> elements
+        foreach ($elements as $element) {
+            if ($element instanceof \DOMElement) {
+                $attributes = $element->attributes;
+
+                // each <figure> element should only contain one table
+                /** @var \DOMElement $node */
+                $tableElement = $element->childNodes[0];
+
+                /** @var \DOMAttr $attribute */
+                foreach ($attributes as $attribute) {
+                    if ($attribute->name === 'class') {
+                        $tableElement->setAttribute('class', $attribute->value);
+                    }
+
+                    if (strpos($attribute->name, 'data-ezattribute-') === 0) {
+                        $tableElement->setAttribute($attribute->name, $attribute->value);
+                    }
+                }
+            }
+        }
+
+        return $document;
+    }
+}

--- a/src/lib/RichText/Converter/Figure.php
+++ b/src/lib/RichText/Converter/Figure.php
@@ -33,7 +33,6 @@ class Figure implements Converter
         $xpathExpression = '//ns:figure [descendant::ns:table]';
         $ns = $document->documentElement ? $document->documentElement->namespaceURI ?: '' : '';
         $xpath->registerNamespace('ns', $ns);
-        /** @var \DomNodeList $elements */
         $elements = $xpath->query($xpathExpression) ?: [];
 
         // elements are list of <figure> elements
@@ -41,18 +40,19 @@ class Figure implements Converter
             if ($element instanceof \DOMElement) {
                 $attributes = $element->attributes;
 
-                // each <figure> element should only contain one table
-                /** @var \DOMElement $node */
-                $tableElement = $element->childNodes[0];
+                // Each <figure> element should only contain one table
+                if ($element->childNodes[0] instanceof \DomElement) {
+                    $tableElement = $element->childNodes[0];
 
-                /** @var \DOMAttr $attribute */
-                foreach ($attributes as $attribute) {
-                    if ($attribute->name === 'class') {
-                        $tableElement->setAttribute('class', $attribute->value);
-                    }
+                    /** @var \DOMAttr $attribute */
+                    foreach ($attributes as $attribute) {
+                        if ($attribute->name === 'class') {
+                            $tableElement->setAttribute('class', $attribute->value);
+                        }
 
-                    if (strpos($attribute->name, 'data-ezattribute-') === 0) {
-                        $tableElement->setAttribute($attribute->name, $attribute->value);
+                        if (strpos($attribute->name, 'data-ezattribute-') === 0) {
+                            $tableElement->setAttribute($attribute->name, $attribute->value);
+                        }
                     }
                 }
             }

--- a/tests/lib/RichText/Converter/Xslt/Xhtml5ToDocbookTest.php
+++ b/tests/lib/RichText/Converter/Xslt/Xhtml5ToDocbookTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\FieldTypeRichText\RichText\Converter\Xslt;
 
 use Ibexa\FieldTypeRichText\RichText\Converter\Aggregate;
+use Ibexa\FieldTypeRichText\RichText\Converter\Figure;
 use Ibexa\FieldTypeRichText\RichText\Converter\ProgramListing;
 use Ibexa\FieldTypeRichText\RichText\Converter\Xslt;
 
@@ -106,6 +107,7 @@ class Xhtml5ToDocbookTest extends BaseTest
             $this->converter = new Aggregate(
                 [
                     new ProgramListing(),
+                    new Figure(),
                     new Xslt(
                         $this->getConversionTransformationStylesheet(),
                         $this->getCustomConversionTransformationStylesheets()

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/009-tableWithCustomClassesAndAttributes.docbook.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/009-tableWithCustomClassesAndAttributes.docbook.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:ezcustom="http://ibexa.co/xmlns/dxp/docbook/custom" xmlns:ezxhtml="http://ibexa.co/xmlns/dxp/docbook/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
+    <para ezxhtml:class="p-special">
+        <ezattribute>
+            <ezvalue key="p-custom-attribute">true</ezvalue>
+            <ezvalue key="p-another-attribute">attr2,attr1</ezvalue>
+        </ezattribute>sdf V8</para>
+    <informaltable class="table t-special">
+        <ezattribute>
+            <ezvalue key="t-custom-attribute">true</ezvalue>
+            <ezvalue key="t-another-attribute">attr2,attr1</ezvalue>
+        </ezattribute>
+        <tbody>
+            <tr>
+                <td> </td>
+                <td> </td>
+            </tr>
+            <tr>
+                <td> </td>
+                <td> </td>
+            </tr>
+            <tr>
+                <td> </td>
+                <td> </td>
+            </tr>
+            <tr>
+                <td> </td>
+                <td> </td>
+            </tr>
+        </tbody>
+    </informaltable>
+</section>

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/009-tableWithCustomClassesAndAttributes.xhtml5.edit.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/009-tableWithCustomClassesAndAttributes.xhtml5.edit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<section xmlns="http://ibexa.co/namespaces/ezpublish5/xhtml5/edit">
+    <p class="p-special" data-ezattribute-p-custom-attribute="true" data-ezattribute-p-another-attribute="attr2,attr1">sdf V8</p>
+    <figure class="table t-special" data-ezattribute-t-custom-attribute="true" data-ezattribute-t-another-attribute="attr2,attr1">
+        <table>
+            <tbody>
+                <tr>
+                    <td> </td>
+                    <td> </td>
+                </tr>
+                <tr>
+                    <td> </td>
+                    <td> </td>
+                </tr>
+                <tr>
+                    <td> </td>
+                    <td> </td>
+                </tr>
+                <tr>
+                    <td> </td>
+                    <td> </td>
+                </tr>
+            </tbody>
+        </table>
+    </figure>
+</section>

--- a/tests/lib/RichText/Validator/DocbookTest.php
+++ b/tests/lib/RichText/Validator/DocbookTest.php
@@ -114,6 +114,41 @@ class DocbookTest extends TestCase
 </section>',
                 [],
             ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:ezcustom="http://ibexa.co/xmlns/dxp/docbook/custom" xmlns:ezxhtml="http://ibexa.co/xmlns/dxp/docbook/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
+    <para ezxhtml:class="p-special">
+        <ezattribute>
+            <ezvalue key="p-custom-attribute">true</ezvalue>
+            <ezvalue key="p-another-attribute">attr2,attr1</ezvalue>
+        </ezattribute>sdf V8</para>
+    <informaltable class="p-special">
+        <ezattribute>
+            <ezvalue key="p-custom-attribute">true</ezvalue>
+            <ezvalue key="p-another-attribute">attr2,attr1</ezvalue>
+        </ezattribute>
+        <tbody>
+            <tr>
+                <td> </td>
+                <td> </td>
+            </tr>
+            <tr>
+                <td> </td>
+                <td> </td>
+            </tr>
+            <tr>
+                <td> </td>
+                <td> </td>
+            </tr>
+            <tr>
+                <td> </td>
+                <td> </td>
+            </tr>
+        </tbody>
+    </informaltable>
+</section>',
+                [],
+            ],
         ];
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-6077](https://issues.ibexa.co/browse/IBX-6077)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

### EDIT : I have made a new PR where the whole problem is solved in XSLT. I think that is a better alternative : #107 

The editor used in 4.x saves tables inside [a `<figure>` element](https://ckeditor.github.io/editor-recommendations/features/table.html). The editor would then save `class` and `data-ezattribute` on the `<figure>` element, instead of in the `<table>`.
We did apparently not fix our converters accordingly for 4.x.

I have solved it by making a php converter that simply copies the `class` and `data-ezattribute` attributes from `<figure>` to `<table>` element. It could have been done in XSLT too, but AFAIK we could not have reused templates like `ezattribute`. Instead it would be cut&paste from that template but fetching attributes from ancestor instead of current node.

I have not done anything with docbook->xhtml5.edit transformation. It seems like editor is backward compatible and also deals fine with having missing `<figure>` element and the attributes stored on `<table>` element as before..

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
