### PR TITLE
IBX-5871: Changed check if @xlink:title exists and not empty for a link element

### DIFF
--- a/src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/output/core.xsl
@@ -250,7 +250,7 @@
               <xsl:value-of select="@xml:id"/>
             </xsl:attribute>
           </xsl:if>
-          <xsl:if test="@xlink:title">
+          <xsl:if test="not(normalize-space(@xlink:title) = '')">
             <xsl:attribute name="title">
               <xsl:value-of select="@xlink:title"/>
             </xsl:attribute>

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/docbook/014-link.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/docbook/014-link.xml
@@ -33,5 +33,8 @@
 with some line break</link>
     </literallayout>
   </para>
+  <para>
+    <link xlink:href="ezcontent://333" xlink:show="none" xml:id="id8" xlink:title="" ezxhtml:class="linkClass5">Link without title</link>
+  </para>
   <para><anchor xml:id="anchor"/>Some anchored content.</para>
 </section>

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/edit/014-link.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/edit/014-link.xml
@@ -22,5 +22,8 @@
   <p>
     <a href="ezcontent://444" id="id7" title="Content title" class="linkClass7">Content name<br/>with some line break</a>
   </p>
+  <p>
+    <a class="linkClass5" href="ezcontent://333" id="id8" title="">Link without title</a>
+  </p>
   <p><a id="anchor"/>Some anchored content.</p>
 </section>

--- a/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/output/014-link.xml
+++ b/tests/lib/RichText/Converter/Xslt/_fixtures/xhtml5/output/014-link.xml
@@ -22,5 +22,8 @@
   <p>
     <a href="ezcontent://444" id="id7" title="Content title" class="linkClass7">Content name<br/>with some line break</a>
   </p>
+  <p>
+    <a class="linkClass5" href="ezcontent://333" id="id8">Link without title</a>
+  </p>
   <p><a id="anchor"/>Some anchored content.</p>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5871](https://issues.ibexa.co/browse/IBX-5871)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `v4.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
