### PR TITLE
IBX-6217: Forced `RichText\Renderer`to utilize `PermissionResolver` instead of `AuthorizationChecker`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2966,16 +2966,6 @@ parameters:
 			path: tests/lib/RichText/RendererTest.php
 
 		-
-			message: "#^Property Ibexa\\\\Tests\\\\FieldTypeRichText\\\\RichText\\\\RendererTest\\:\\:\\$authorizationCheckerMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Symfony\\\\Component\\\\Security\\\\Core\\\\Authorization\\\\AuthorizationCheckerInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\FieldTypeRichText\\\\RichText\\\\RendererTest\\:\\:\\$configResolverMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Psr\\\\Log\\\\LoggerInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
 			message: "#^Property Ibexa\\\\Tests\\\\FieldTypeRichText\\\\RichText\\\\RendererTest\\:\\:\\$loaderMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Twig\\\\Loader\\\\LoaderInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
 			count: 1
 			path: tests/lib/RichText/RendererTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2966,26 +2966,6 @@ parameters:
 			path: tests/lib/RichText/RendererTest.php
 
 		-
-			message: "#^Property Ibexa\\\\Tests\\\\FieldTypeRichText\\\\RichText\\\\RendererTest\\:\\:\\$loaderMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Twig\\\\Loader\\\\LoaderInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\FieldTypeRichText\\\\RichText\\\\RendererTest\\:\\:\\$loggerMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Psr\\\\Log\\\\LoggerInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\FieldTypeRichText\\\\RichText\\\\RendererTest\\:\\:\\$repositoryMock \\(Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Repository&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\FieldTypeRichText\\\\RichText\\\\RendererTest\\:\\:\\$templateEngineMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Symfony\\\\Component\\\\Templating\\\\EngineInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\FieldTypeRichText\\\\RichText\\\\Validator\\\\CustomTagsValidatorTest\\:\\:providerForTestValidateDocument\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/lib/RichText/Validator/CustomTagsValidatorTest.php

--- a/src/bundle/Resources/config/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/fieldtype_services.yaml
@@ -31,18 +31,17 @@ services:
                 http://ibexa.co/namespaces/ezpublish5/xhtml5/edit: '@ibexa.richtext.converter.input.xhtml5'
 
     Ibexa\FieldTypeRichText\RichText\Renderer:
-        class: Ibexa\FieldTypeRichText\RichText\Renderer
         arguments:
-            - '@ibexa.api.repository'
-            - '@security.authorization_checker'
-            - '@ibexa.config.resolver'
-            - '@twig'
-            - '%ibexa.field_type.richtext.tag.namespace%'
-            - '%ibexa.field_type.richtext.style.namespace%'
-            - '%ibexa.field_type.richtext.embed.namespace%'
-            - '@?logger'
-            - '%ibexa.field_type.richtext.custom_tags%'
-            - '%ibexa.field_type.richtext.custom_styles%'
+            $repository: '@ibexa.api.repository'
+            $configResolver: '@ibexa.config.resolver'
+            $templateEngine: '@twig'
+            $permissionResolver: '@Ibexa\Contracts\Core\Repository\PermissionResolver'
+            $tagConfigurationNamespace: '%ibexa.field_type.richtext.tag.namespace%'
+            $styleConfigurationNamespace: '%ibexa.field_type.richtext.style.namespace%'
+            $embedConfigurationNamespace: '%ibexa.field_type.richtext.embed.namespace%'
+            $logger: '@?logger'
+            $customTagsConfiguration: '%ibexa.field_type.richtext.custom_tags%'
+            $customStylesConfiguration: '%ibexa.field_type.richtext.custom_styles%'
 
     Ibexa\FieldTypeRichText\RichText\Converter\Link:
         class: Ibexa\FieldTypeRichText\RichText\Converter\Link

--- a/src/lib/RichText/Renderer.php
+++ b/src/lib/RichText/Renderer.php
@@ -81,9 +81,9 @@ class Renderer implements RendererInterface
         ConfigResolverInterface $configResolver,
         Environment $templateEngine,
         PermissionResolver $permissionResolver,
-        $tagConfigurationNamespace,
-        $styleConfigurationNamespace,
-        $embedConfigurationNamespace,
+        string $tagConfigurationNamespace,
+        string $styleConfigurationNamespace,
+        string $embedConfigurationNamespace,
         LoggerInterface $logger = null,
         array $customTagsConfiguration = [],
         array $customStylesConfiguration = []

--- a/src/lib/RichText/Renderer.php
+++ b/src/lib/RichText/Renderer.php
@@ -10,15 +10,14 @@ namespace Ibexa\FieldTypeRichText\RichText;
 
 use Exception;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Contracts\FieldTypeRichText\RichText\RendererInterface;
-use Ibexa\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Twig\Environment;
 
@@ -35,10 +34,7 @@ class Renderer implements RendererInterface
      */
     protected $repository;
 
-    /**
-     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
-     */
-    private $authorizationChecker;
+    private PermissionResolver $permissionResolver;
 
     /**
      * @var string
@@ -80,23 +76,11 @@ class Renderer implements RendererInterface
      */
     private $customStylesConfiguration;
 
-    /**
-     * @param \Ibexa\Contracts\Core\Repository\Repository $repository
-     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker
-     * @param \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface $configResolver
-     * @param \Twig\Environment $templateEngine
-     * @param string $tagConfigurationNamespace
-     * @param string $styleConfigurationNamespace
-     * @param string $embedConfigurationNamespace
-     * @param \Psr\Log\LoggerInterface|null $logger
-     * @param array $customTagsConfiguration
-     * @param array $customStylesConfiguration
-     */
     public function __construct(
         Repository $repository,
-        AuthorizationCheckerInterface $authorizationChecker,
         ConfigResolverInterface $configResolver,
         Environment $templateEngine,
+        PermissionResolver $permissionResolver,
         $tagConfigurationNamespace,
         $styleConfigurationNamespace,
         $embedConfigurationNamespace,
@@ -105,9 +89,9 @@ class Renderer implements RendererInterface
         array $customStylesConfiguration = []
     ) {
         $this->repository = $repository;
-        $this->authorizationChecker = $authorizationChecker;
         $this->configResolver = $configResolver;
         $this->templateEngine = $templateEngine;
+        $this->permissionResolver = $permissionResolver;
         $this->tagConfigurationNamespace = $tagConfigurationNamespace;
         $this->styleConfigurationNamespace = $styleConfigurationNamespace;
         $this->embedConfigurationNamespace = $embedConfigurationNamespace;
@@ -452,20 +436,15 @@ class Renderer implements RendererInterface
     /**
      * Check embed permissions for the given Content.
      *
-     * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content $content
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
      */
     protected function checkContentPermissions(Content $content)
     {
         // Check both 'content/read' and 'content/view_embed'.
         if (
-            !$this->authorizationChecker->isGranted(
-                new AuthorizationAttribute('content', 'read', ['valueObject' => $content])
-            )
-            && !$this->authorizationChecker->isGranted(
-                new AuthorizationAttribute('content', 'view_embed', ['valueObject' => $content])
-            )
+            !$this->permissionResolver->canUser('content', 'read', $content)
+            && !$this->permissionResolver->canUser('content', 'view_embed', $content) // Shouldn't we have `||` here?
         ) {
             throw new AccessDeniedException();
         }
@@ -473,9 +452,7 @@ class Renderer implements RendererInterface
         // Check that Content is published, since sudo allows loading unpublished content.
         if (
             !$content->getVersionInfo()->isPublished()
-            && !$this->authorizationChecker->isGranted(
-                new AuthorizationAttribute('content', 'versionread', ['valueObject' => $content])
-            )
+            && !$this->permissionResolver->canUser('content', 'versionread', $content)
         ) {
             throw new AccessDeniedException();
         }
@@ -501,19 +478,17 @@ class Renderer implements RendererInterface
 
         // Check both 'content/read' and 'content/view_embed'.
         if (
-            !$this->authorizationChecker->isGranted(
-                new AuthorizationAttribute(
-                    'content',
-                    'read',
-                    ['valueObject' => $location->contentInfo, 'targets' => [$location]]
-                )
+            !$this->permissionResolver->canUser(
+                'content',
+                'read',
+                $location->contentInfo,
+                [$location]
             )
-            && !$this->authorizationChecker->isGranted(
-                new AuthorizationAttribute(
-                    'content',
-                    'view_embed',
-                    ['valueObject' => $location->contentInfo, 'targets' => [$location]]
-                )
+            && !$this->permissionResolver->canUser( // Shouldn't we have `||` here?
+                'content',
+                'view_embed',
+                $location->contentInfo,
+                [$location]
             )
         ) {
             throw new AccessDeniedException();

--- a/tests/lib/RichText/RendererTest.php
+++ b/tests/lib/RichText/RendererTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\FieldTypeRichText\RichText;
 
 use Exception;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
@@ -19,7 +20,6 @@ use Ibexa\FieldTypeRichText\RichText\Renderer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Twig\Environment;
 use Twig\Loader\LoaderInterface;
@@ -29,7 +29,7 @@ class RendererTest extends TestCase
     public function setUp(): void
     {
         $this->repositoryMock = $this->getRepositoryMock();
-        $this->authorizationCheckerMock = $this->getAuthorizationCheckerMock();
+        $this->permissionResolverMock = $this->getPermissionResolverMock();
         $this->configResolverMock = $this->getConfigResolverMock();
         $this->templateEngineMock = $this->getTemplateEngineMock();
         $this->loggerMock = $this->getLoggerMock();
@@ -1707,9 +1707,9 @@ class RendererTest extends TestCase
             ->setConstructorArgs(
                 [
                     $this->repositoryMock,
-                    $this->authorizationCheckerMock,
                     $this->configResolverMock,
                     $this->templateEngineMock,
+                    $this->permissionResolverMock,
                     'test.name.space.tag',
                     'test.name.space.style',
                     'test.name.space.embed',
@@ -1734,16 +1734,16 @@ class RendererTest extends TestCase
     }
 
     /**
-     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Ibexa\Contracts\Core\Repository\PermissionResolver|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $authorizationCheckerMock;
+    protected $permissionResolverMock;
 
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getAuthorizationCheckerMock()
+    protected function getPermissionResolverMock()
     {
-        return $this->createMock(AuthorizationCheckerInterface::class);
+        return $this->createMock(PermissionResolver::class);
     }
 
     /**

--- a/tests/lib/RichText/RendererTest.php
+++ b/tests/lib/RichText/RendererTest.php
@@ -1721,7 +1721,7 @@ class RendererTest extends TestCase
     }
 
     /** @var \Ibexa\Contracts\Core\Repository\Repository&\PHPUnit\Framework\MockObject\MockObject */
-    protected $repositoryMock;
+    protected Repository $repositoryMock;
 
     /**
      * @return \Ibexa\Core\Repository\Repository&\PHPUnit\Framework\MockObject\MockObject

--- a/tests/lib/RichText/RendererTest.php
+++ b/tests/lib/RichText/RendererTest.php
@@ -17,7 +17,6 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\Repository\Repository;
 use Ibexa\FieldTypeRichText\RichText\Renderer;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -1721,65 +1720,57 @@ class RendererTest extends TestCase
             ->getMock();
     }
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\Repository|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var \Ibexa\Contracts\Core\Repository\Repository&\PHPUnit\Framework\MockObject\MockObject */
     protected $repositoryMock;
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return \Ibexa\Core\Repository\Repository&\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getRepositoryMock()
+    protected function getRepositoryMock(): Repository
     {
         return $this->createMock(Repository::class);
     }
 
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface&\PHPUnit\Framework\MockObject\MockObject */
-    protected $configResolverMock;
+    protected ConfigResolverInterface $configResolverMock;
 
     /**
      * @return \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface&\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getConfigResolverMock()
+    protected function getConfigResolverMock(): ConfigResolverInterface
     {
         return $this->createMock(ConfigResolverInterface::class);
     }
 
-    /**
-     * @var \Symfony\Component\Templating\EngineInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $templateEngineMock;
+    /** @var \Twig\Environment&\PHPUnit\Framework\MockObject\MockObject */
+    protected Environment $templateEngineMock;
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return \Twig\Environment&\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getTemplateEngineMock()
+    protected function getTemplateEngineMock(): Environment
     {
         return $this->createMock(Environment::class);
     }
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\PermissionResolver&\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $permissionResolverMock;
+    /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver&\PHPUnit\Framework\MockObject\MockObject */
+    protected PermissionResolver $permissionResolverMock;
 
     /**
      * @return \Ibexa\Contracts\Core\Repository\PermissionResolver&\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getPermissionResolverMock(): MockObject
+    protected function getPermissionResolverMock(): PermissionResolver
     {
         return $this->createMock(PermissionResolver::class);
     }
 
-    /**
-     * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $loggerMock;
+    /** @var \Psr\Log\LoggerInterface&\PHPUnit\Framework\MockObject\MockObject */
+    protected LoggerInterface $loggerMock;
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return \Psr\Log\LoggerInterface&\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getLoggerMock()
+    protected function getLoggerMock(): LoggerInterface
     {
         return $this->createMock(LoggerInterface::class);
     }
@@ -1790,9 +1781,9 @@ class RendererTest extends TestCase
     protected $loaderMock;
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return \Twig\Loader\LoaderInterface&\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getLoaderMock()
+    protected function getLoaderMock(): LoaderInterface
     {
         return $this->createMock(LoaderInterface::class);
     }

--- a/tests/lib/RichText/RendererTest.php
+++ b/tests/lib/RichText/RendererTest.php
@@ -15,7 +15,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
-use Ibexa\Core\Repository\Repository;
+use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\FieldTypeRichText\RichText\Renderer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -1724,7 +1724,7 @@ class RendererTest extends TestCase
     protected Repository $repositoryMock;
 
     /**
-     * @return \Ibexa\Core\Repository\Repository&\PHPUnit\Framework\MockObject\MockObject
+     * @return \Ibexa\Contracts\Core\Repository\Repository&\PHPUnit\Framework\MockObject\MockObject
      */
     protected function getRepositoryMock(): Repository
     {

--- a/tests/lib/RichText/RendererTest.php
+++ b/tests/lib/RichText/RendererTest.php
@@ -10,12 +10,12 @@ namespace Ibexa\Tests\FieldTypeRichText\RichText;
 
 use Exception;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
-use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\FieldTypeRichText\RichText\Renderer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;

--- a/tests/lib/RichText/RendererTest.php
+++ b/tests/lib/RichText/RendererTest.php
@@ -17,6 +17,7 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\Repository\Repository;
 use Ibexa\FieldTypeRichText\RichText\Renderer;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -1733,26 +1734,11 @@ class RendererTest extends TestCase
         return $this->createMock(Repository::class);
     }
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\PermissionResolver|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $permissionResolverMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getPermissionResolverMock()
-    {
-        return $this->createMock(PermissionResolver::class);
-    }
-
-    /**
-     * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface&\PHPUnit\Framework\MockObject\MockObject */
     protected $configResolverMock;
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface&\PHPUnit\Framework\MockObject\MockObject
      */
     protected function getConfigResolverMock()
     {
@@ -1770,6 +1756,19 @@ class RendererTest extends TestCase
     protected function getTemplateEngineMock()
     {
         return $this->createMock(Environment::class);
+    }
+
+    /**
+     * @var \Ibexa\Contracts\Core\Repository\PermissionResolver&\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $permissionResolverMock;
+
+    /**
+     * @return \Ibexa\Contracts\Core\Repository\PermissionResolver&\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getPermissionResolverMock(): MockObject
+    {
+        return $this->createMock(PermissionResolver::class);
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-6217](https://issues.ibexa.co/browse/IBX-6217)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | `v4.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
