### PR TITLE
IBX-6313: Allowed empty paragraph to be converted to XML using Xslt

### DIFF
--- a/src/bundle/Resources/richtext/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/bundle/Resources/richtext/stylesheets/xhtml5/edit/docbook.xsl
@@ -129,6 +129,9 @@
       <xsl:call-template name="breaklineWithLiterallayout">
         <xsl:with-param name="node" select="node()"/>
       </xsl:call-template>
+      <xsl:if test="not(node() or @*)">
+        <xsl:text>&#160;</xsl:text>
+      </xsl:if>
     </para>
   </xsl:template>
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-6313](https://issues.ibexa.co/browse/IBX-6313)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `v4.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This also resolve the problem with an empty anchor not being saved (that's because paragraph couldn't be saved).

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
