### PR TITLE
IBX-6354: Set z-index for .ck-toolbar-container and .ck-balloon-panel_with-arrow

### DIFF
--- a/src/bundle/Resources/public/scss/_balloon-form.scss
+++ b/src/bundle/Resources/public/scss/_balloon-form.scss
@@ -132,7 +132,11 @@
         }
     }
 
-    .ck-balloon-panel_visible {
-        z-index: 300;
+    .ck-toolbar-container {
+        z-index: calc(var(--ck-z-modal) - 1);
+
+        &.ck-balloon-panel_with-arrow {
+            z-index: calc(var(--ck-z-modal) + 1);
+        }
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-6354](https://issues.ibexa.co/browse/IBX-6354)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `v4.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Added z-index for ck-balloon-panel_with-arrow because a problem with the toolbar for image variations was also detected


**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
