### PR TITLE
IBX-6467: Richtext field validation is not styled properly

### DIFF
--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -233,6 +233,26 @@
     }
 }
 
+.ibexa-field-edit--ezrichtext {
+    .ibexa-data-source__richtext.ck.ck-editor__editable.ck-rounded-corners:not(.ck-editor__nested-editable) {
+        border-radius: $ibexa-border-radius $ibexa-border-radius 0 0;
+    }
+
+    &.is-invalid {
+        .ibexa-label {
+            color: $ibexa-color-danger;
+        }
+
+        .ibexa-data-source {
+            border-color: $ibexa-color-danger;
+        }
+
+        .ibexa-data-source__richtext {
+            background-color: $ibexa-color-danger-100;
+        }
+    }
+}
+
 .ck {
     &.ck-editor__editable_inline {
         border: none;

--- a/src/bundle/Resources/public/scss/variables/colors.scss
+++ b/src/bundle/Resources/public/scss/variables/colors.scss
@@ -16,6 +16,7 @@ $ibexa-color-dark-300: #a0a4a8 !default;
 $ibexa-color-dark-200: #cfd1d3 !default;
 
 $ibexa-color-danger: #db0032 !default;
+$ibexa-color-danger-100: #fbe5ea !default;
 
 $ibexa-btn-focus-box-shadow: 0 0 0 calculateRem(3px) rgba($ibexa-color-primary, 0.2) !default;
 $ibexa-btn-hover-box-shadow: 0 calculateRem(22px) calculateRem(24px) 0 rgba($ibexa-color-danger, 0.2) !default;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-6467](https://issues.ibexa.co/browse/IBX-6467)
| **Bug**| yes
| **New feature**    | no
| **Target version** | 4.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Fixed styles for `is invalid` state and `focus` state

**Is invalid**
![Screenshot 2023-09-19 at 12 03 07](https://github.com/ibexa/fieldtype-richtext/assets/24355391/29561817-25c3-48ca-9651-fb4caaa84835)

**Focus**
![Screenshot 2023-09-19 at 12 02 54](https://github.com/ibexa/fieldtype-richtext/assets/24355391/04992513-66ec-4f13-b7fb-6221709ea115)


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
