### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/actions/composer-install/action.yaml
+++ b/.github/actions/composer-install/action.yaml
@@ -7,8 +7,8 @@ runs:
                 version=$(jq -r '.extra | ."branch-alias" | ."dev-main"' < composer.json)
                 echo "version=$version" >> $GITHUB_ENV
             shell: bash
-        -   uses: ramsey/composer-install@v2
+        -   uses: ramsey/composer-install@v3
             with:
-                dependency-versions: "highest"
+                dependency-versions: highest
             env:
                 COMPOSER_ROOT_VERSION: ${{ env.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - '8.0'
+                    - '8.3'
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -40,12 +40,10 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                    - '8.1'
+                    - '8.3'
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -90,12 +88,10 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                    - '8.1'
+                    - '8.3'
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -141,12 +137,10 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                    - '8.1'
+                    - '8.3'
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -183,7 +177,7 @@ jobs:
                     --health-timeout 5s
                     --health-retries 10
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -14,8 +14,8 @@ jobs:
         timeout-minutes: 5
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: '18'
             - run: yarn install

--- a/composer.json
+++ b/composer.json
@@ -6,51 +6,51 @@
         "ezsystems/ezplatform-richtext": "*"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": " >=8.3",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-pdo": "*",
         "ext-xsl": "*",
+        "ibexa/content-forms": "~5.0.x-dev",
+        "ibexa/core": "~5.0.x-dev",
+        "ibexa/http-cache": "~5.0.x-dev",
+        "ibexa/rest": "~5.0.x-dev",
         "symfony/asset": "^5.1",
-        "symfony/dependency-injection": "^5.0",
-        "symfony/http-kernel": "^5.0",
-        "symfony/config": "^5.0",
-        "symfony/yaml": "^5.0",
-        "symfony/templating": "^5.0",
-        "symfony/security-core": "^5.0",
-        "symfony/form": "^5.0",
-        "symfony/options-resolver": "^5.0",
-        "symfony/validator": "^5.0",
         "symfony/cache": "^5.0",
+        "symfony/config": "^5.0",
+        "symfony/dependency-injection": "^5.0",
+        "symfony/form": "^5.0",
+        "symfony/http-kernel": "^5.0",
+        "symfony/options-resolver": "^5.0",
+        "symfony/security-core": "^5.0",
+        "symfony/templating": "^5.0",
         "symfony/translation": "^5.0",
         "symfony/translation-contracts": "^2.0",
-        "twig/twig": "^3.0",
-        "ibexa/core": "~5.0.x-dev",
-        "ibexa/content-forms": "~5.0.x-dev",
-        "ibexa/rest": "~5.0.x-dev",
-        "ibexa/http-cache": "~5.0.x-dev"
+        "symfony/validator": "^5.0",
+        "symfony/yaml": "^5.0",
+        "twig/twig": "^3.0"
     },
     "require-dev": {
         "dama/doctrine-test-bundle": "^6.7.5",
         "ibexa/admin-ui": "~5.0.x-dev",
-        "ibexa/design-engine": "~5.0.x-dev",
         "ibexa/ci-scripts": "^0.2@dev",
+        "ibexa/code-style": "^1.0",
+        "ibexa/design-engine": "~5.0.x-dev",
         "ibexa/doctrine-schema": "~5.0.x-dev",
         "ibexa/notifications": "~5.0.x-dev",
         "ibexa/search": "~5.0.x-dev",
         "ibexa/solr": "~5.0.x-dev",
         "ibexa/test-core": "~5.0.x-dev",
         "ibexa/user": "~5.0.x-dev",
+        "matthiasnoback/symfony-config-test": "^4.1",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpstan/phpstan": "^1.9",
-        "phpstan/phpstan-symfony": "^1.2",
         "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/phpstan-symfony": "^1.2",
         "phpunit/phpunit": "^9.5",
         "symfony/finder": "^5.0",
         "symfony/notifier": "^5.4",
-        "symfony/proxy-manager-bridge": "^5.3",
-        "matthiasnoback/symfony-config-test": "^4.1",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "ibexa/code-style": "^1.0"
+        "symfony/proxy-manager-bridge": "^5.3"
     },
     "autoload": {
         "psr-4": {
@@ -87,6 +87,7 @@
         }
     },
     "config": {
-        "allow-plugins": false
+        "allow-plugins": false,
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!--
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes)
-->
