### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,9 +57,7 @@
             "Ibexa\\FieldTypeRichText\\": "src/lib/",
             "Ibexa\\Contracts\\FieldTypeRichText\\": "src/contracts/",
             "Ibexa\\Bundle\\FieldTypeRichText\\": "src/bundle/",
-            "Ibexa\\Tests\\FieldTypeRichText\\": "tests/lib/",
-            "EzSystems\\EzPlatformRichTextBundle\\": "src/bundle",
-            "EzSystems\\EzPlatformRichText\\": "src/lib"
+            "Ibexa\\Tests\\FieldTypeRichText\\": "tests/lib/"
         }
     },
     "autoload-dev": {

--- a/src/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
+++ b/src/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
@@ -75,5 +75,3 @@ class RichTextHtml5ConverterPass implements CompilerPassInterface
         return array_merge(...$convertersByPriority);
     }
 }
-
-class_alias(RichTextHtml5ConverterPass::class, 'EzSystems\EzPlatformRichTextBundle\DependencyInjection\Compiler\RichTextHtml5ConverterPass');

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -214,5 +214,3 @@ class Configuration extends SiteAccessConfiguration
         ;
     }
 }
-
-class_alias(Configuration::class, 'EzSystems\EzPlatformRichTextBundle\DependencyInjection\Configuration');

--- a/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -425,5 +425,3 @@ class RichText extends AbstractFieldTypeParser
         };
     }
 }
-
-class_alias(RichText::class, 'EzSystems\EzPlatformRichTextBundle\DependencyInjection\Configuration\Parser\FieldType\RichText');

--- a/src/bundle/DependencyInjection/IbexaFieldTypeRichTextExtension.php
+++ b/src/bundle/DependencyInjection/IbexaFieldTypeRichTextExtension.php
@@ -306,5 +306,3 @@ class IbexaFieldTypeRichTextExtension extends Extension implements PrependExtens
         }
     }
 }
-
-class_alias(IbexaFieldTypeRichTextExtension::class, 'EzSystems\EzPlatformRichTextBundle\DependencyInjection\EzPlatformRichTextExtension');

--- a/src/bundle/IbexaFieldTypeRichTextBundle.php
+++ b/src/bundle/IbexaFieldTypeRichTextBundle.php
@@ -56,5 +56,3 @@ class IbexaFieldTypeRichTextBundle extends Bundle
         return $this->extension;
     }
 }
-
-class_alias(IbexaFieldTypeRichTextBundle::class, 'EzSystems\EzPlatformRichTextBundle\EzPlatformRichTextBundle');

--- a/src/bundle/Templating/Twig/Extension/RichTextConfigurationExtension.php
+++ b/src/bundle/Templating/Twig/Extension/RichTextConfigurationExtension.php
@@ -38,5 +38,3 @@ final class RichTextConfigurationExtension extends AbstractExtension implements 
         ];
     }
 }
-
-class_alias(RichTextConfigurationExtension::class, 'EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension\RichTextConfigurationExtension');

--- a/src/bundle/Templating/Twig/Extension/RichTextConverterExtension.php
+++ b/src/bundle/Templating/Twig/Extension/RichTextConverterExtension.php
@@ -73,5 +73,3 @@ class RichTextConverterExtension extends AbstractExtension
         return $this->richTextEditConverter->convert($xmlData)->saveHTML() ?: '';
     }
 }
-
-class_alias(RichTextConverterExtension::class, 'EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension\RichTextConverterExtension');

--- a/src/bundle/Templating/Twig/Extension/YoutubeIdExtractorExtension.php
+++ b/src/bundle/Templating/Twig/Extension/YoutubeIdExtractorExtension.php
@@ -49,5 +49,3 @@ final class YoutubeIdExtractorExtension extends AbstractExtension
         return $matches['id'] ?? null;
     }
 }
-
-class_alias(YoutubeIdExtractorExtension::class, 'EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension\YoutubeIdExtractorExtension');

--- a/src/contracts/Configuration/Provider.php
+++ b/src/contracts/Configuration/Provider.php
@@ -29,5 +29,3 @@ interface Provider
      */
     public function getConfiguration(): array;
 }
-
-class_alias(Provider::class, 'EzSystems\EzPlatformRichText\SPI\Configuration\Provider');

--- a/src/contracts/Configuration/ProviderService.php
+++ b/src/contracts/Configuration/ProviderService.php
@@ -25,5 +25,3 @@ interface ProviderService
      */
     public function getConfiguration(): array;
 }
-
-class_alias(ProviderService::class, 'EzSystems\EzPlatformRichText\API\Configuration\ProviderService');

--- a/src/contracts/RichText/Converter.php
+++ b/src/contracts/RichText/Converter.php
@@ -24,5 +24,3 @@ interface Converter
      */
     public function convert(DOMDocument $xmlDoc);
 }
-
-class_alias(Converter::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Converter');

--- a/src/contracts/RichText/InputHandlerInterface.php
+++ b/src/contracts/RichText/InputHandlerInterface.php
@@ -55,5 +55,3 @@ interface InputHandlerInterface
      */
     public function validate(DOMDocument $document): array;
 }
-
-class_alias(InputHandlerInterface::class, 'EzSystems\EzPlatformRichText\eZ\RichText\InputHandlerInterface');

--- a/src/contracts/RichText/RendererInterface.php
+++ b/src/contracts/RichText/RendererInterface.php
@@ -49,5 +49,3 @@ interface RendererInterface
      */
     public function renderLocationEmbed($locationId, $viewType, array $parameters, $isInline);
 }
-
-class_alias(RendererInterface::class, 'EzSystems\EzPlatformRichText\eZ\RichText\RendererInterface');

--- a/src/contracts/RichText/ValidatorInterface.php
+++ b/src/contracts/RichText/ValidatorInterface.php
@@ -21,5 +21,3 @@ interface ValidatorInterface
      */
     public function validateDocument(DOMDocument $xmlDocument): array;
 }
-
-class_alias(ValidatorInterface::class, 'EzSystems\EzPlatformRichText\eZ\RichText\ValidatorInterface');

--- a/src/lib/Configuration/AggregateProvider.php
+++ b/src/lib/Configuration/AggregateProvider.php
@@ -38,5 +38,3 @@ final class AggregateProvider implements ProviderService
         return $configuration;
     }
 }
-
-class_alias(AggregateProvider::class, 'EzSystems\EzPlatformRichText\Configuration\AggregateProvider');

--- a/src/lib/Configuration/Provider/AlloyEditor.php
+++ b/src/lib/Configuration/Provider/AlloyEditor.php
@@ -145,5 +145,3 @@ final class AlloyEditor implements Provider
             : [];
     }
 }
-
-class_alias(AlloyEditor::class, 'EzSystems\EzPlatformRichText\Configuration\Provider\AlloyEditor');

--- a/src/lib/Configuration/Provider/CKEditor.php
+++ b/src/lib/Configuration/Provider/CKEditor.php
@@ -164,5 +164,3 @@ final class CKEditor implements Provider
             : [];
     }
 }
-
-class_alias(CKEditor::class, 'EzSystems\EzPlatformRichText\Configuration\Provider\CKEditor');

--- a/src/lib/Configuration/Provider/CustomStyle.php
+++ b/src/lib/Configuration/Provider/CustomStyle.php
@@ -52,5 +52,3 @@ final class CustomStyle implements Provider
         return [];
     }
 }
-
-class_alias(CustomStyle::class, 'EzSystems\EzPlatformRichText\Configuration\Provider\CustomStyle');

--- a/src/lib/Configuration/Provider/CustomTag.php
+++ b/src/lib/Configuration/Provider/CustomTag.php
@@ -52,5 +52,3 @@ final class CustomTag implements Provider
         return [];
     }
 }
-
-class_alias(CustomTag::class, 'EzSystems\EzPlatformRichText\Configuration\Provider\CustomTag');

--- a/src/lib/Configuration/UI/Mapper/CustomStyle.php
+++ b/src/lib/Configuration/UI/Mapper/CustomStyle.php
@@ -73,5 +73,3 @@ final class CustomStyle implements CustomTemplateConfigMapper
         return $config;
     }
 }
-
-class_alias(CustomStyle::class, 'EzSystems\EzPlatformRichText\Configuration\UI\Mapper\CustomStyle');

--- a/src/lib/Configuration/UI/Mapper/CustomTag.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag.php
@@ -208,5 +208,3 @@ final class CustomTag implements CustomTemplateConfigMapper
         return $config;
     }
 }
-
-class_alias(CustomTag::class, 'EzSystems\EzPlatformRichText\Configuration\UI\Mapper\CustomTag');

--- a/src/lib/Configuration/UI/Mapper/CustomTag/AttributeMapper.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag/AttributeMapper.php
@@ -39,5 +39,3 @@ interface AttributeMapper
         array $customTagAttributeProperties
     ): array;
 }
-
-class_alias(AttributeMapper::class, 'EzSystems\EzPlatformRichText\Configuration\UI\Mapper\CustomTag\AttributeMapper');

--- a/src/lib/Configuration/UI/Mapper/CustomTag/ChoiceAttributeMapper.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag/ChoiceAttributeMapper.php
@@ -40,5 +40,3 @@ final class ChoiceAttributeMapper extends CommonAttributeMapper implements Attri
         return $parentConfig;
     }
 }
-
-class_alias(ChoiceAttributeMapper::class, 'EzSystems\EzPlatformRichText\Configuration\UI\Mapper\CustomTag\ChoiceAttributeMapper');

--- a/src/lib/Configuration/UI/Mapper/CustomTag/CommonAttributeMapper.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag/CommonAttributeMapper.php
@@ -39,5 +39,3 @@ class CommonAttributeMapper implements AttributeMapper
         ];
     }
 }
-
-class_alias(CommonAttributeMapper::class, 'EzSystems\EzPlatformRichText\Configuration\UI\Mapper\CustomTag\CommonAttributeMapper');

--- a/src/lib/Configuration/UI/Mapper/CustomTemplateConfigMapper.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTemplateConfigMapper.php
@@ -15,5 +15,3 @@ interface CustomTemplateConfigMapper
 {
     public function mapConfig(array $enabledCustomTemplates): array;
 }
-
-class_alias(CustomTemplateConfigMapper::class, 'EzSystems\EzPlatformRichText\Configuration\UI\Mapper\CustomTemplateConfigMapper');

--- a/src/lib/Configuration/UI/Mapper/OnlineEditor.php
+++ b/src/lib/Configuration/UI/Mapper/OnlineEditor.php
@@ -87,5 +87,3 @@ final class OnlineEditor implements OnlineEditorConfigMapper
         return $configuration;
     }
 }
-
-class_alias(OnlineEditor::class, 'EzSystems\EzPlatformRichText\Configuration\UI\Mapper\OnlineEditor');

--- a/src/lib/Configuration/UI/Mapper/OnlineEditorConfigMapper.php
+++ b/src/lib/Configuration/UI/Mapper/OnlineEditorConfigMapper.php
@@ -33,5 +33,3 @@ interface OnlineEditorConfigMapper
      */
     public function mapDataAttributesConfiguration(array $semanticConfiguration): array;
 }
-
-class_alias(OnlineEditorConfigMapper::class, 'EzSystems\EzPlatformRichText\Configuration\UI\Mapper\OnlineEditorConfigMapper');

--- a/src/lib/FieldType/RichText/RichTextStorage.php
+++ b/src/lib/FieldType/RichText/RichTextStorage.php
@@ -207,5 +207,3 @@ class RichTextStorage extends GatewayBasedStorage
     {
     }
 }
-
-class_alias(RichTextStorage::class, 'EzSystems\EzPlatformRichText\eZ\FieldType\RichText\RichTextStorage');

--- a/src/lib/FieldType/RichText/RichTextStorage/Gateway.php
+++ b/src/lib/FieldType/RichText/RichTextStorage/Gateway.php
@@ -102,5 +102,3 @@ abstract class Gateway extends StorageGateway
         $this->urlGateway->unlinkUrl($fieldId, $versionNo, $excludeUrlIds);
     }
 }
-
-class_alias(Gateway::class, 'EzSystems\EzPlatformRichText\eZ\FieldType\RichText\RichTextStorage\Gateway');

--- a/src/lib/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
+++ b/src/lib/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
@@ -59,5 +59,3 @@ class DoctrineStorage extends Gateway
         return $objectRemoteIdMap;
     }
 }
-
-class_alias(DoctrineStorage::class, 'EzSystems\EzPlatformRichText\eZ\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage');

--- a/src/lib/FieldType/RichText/SearchField.php
+++ b/src/lib/FieldType/RichText/SearchField.php
@@ -99,5 +99,3 @@ class SearchField implements Indexable
         return $this->getDefaultMatchField();
     }
 }
-
-class_alias(SearchField::class, 'EzSystems\EzPlatformRichText\eZ\FieldType\RichText\SearchField');

--- a/src/lib/FieldType/RichText/Type.php
+++ b/src/lib/FieldType/RichText/Type.php
@@ -297,5 +297,3 @@ class Type extends FieldType implements TranslationContainerInterface
         ];
     }
 }
-
-class_alias(Type::class, 'EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Type');

--- a/src/lib/FieldType/RichText/Value.php
+++ b/src/lib/FieldType/RichText/Value.php
@@ -51,5 +51,3 @@ EOT;
         return isset($this->xml) ? (string)$this->xml->saveXML() : self::EMPTY_VALUE;
     }
 }
-
-class_alias(Value::class, 'EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value');

--- a/src/lib/Form/DataTransformer/RichTextTransformer.php
+++ b/src/lib/Form/DataTransformer/RichTextTransformer.php
@@ -79,5 +79,3 @@ class RichTextTransformer implements DataTransformerInterface
         }
     }
 }
-
-class_alias(RichTextTransformer::class, 'EzSystems\EzPlatformRichText\Form\DataTransformer\RichTextTransformer');

--- a/src/lib/Form/DataTransformer/RichTextValueTransformer.php
+++ b/src/lib/Form/DataTransformer/RichTextValueTransformer.php
@@ -60,5 +60,3 @@ class RichTextValueTransformer implements DataTransformerInterface
         return $this->fieldType->fromHash(['xml' => $value]);
     }
 }
-
-class_alias(RichTextValueTransformer::class, 'EzSystems\EzPlatformRichText\Form\DataTransformer\RichTextValueTransformer');

--- a/src/lib/Form/Mapper/RichTextFormMapper.php
+++ b/src/lib/Form/Mapper/RichTextFormMapper.php
@@ -44,5 +44,3 @@ class RichTextFormMapper implements FieldValueFormMapperInterface
             ]);
     }
 }
-
-class_alias(RichTextFormMapper::class, 'EzSystems\EzPlatformRichText\Form\Mapper\RichTextFormMapper');

--- a/src/lib/Form/Type/RichTextFieldType.php
+++ b/src/lib/Form/Type/RichTextFieldType.php
@@ -55,5 +55,3 @@ class RichTextFieldType extends AbstractType
         ));
     }
 }
-
-class_alias(RichTextFieldType::class, 'EzSystems\EzPlatformRichText\Form\Type\RichTextFieldType');

--- a/src/lib/Form/Type/RichTextType.php
+++ b/src/lib/Form/Type/RichTextType.php
@@ -90,5 +90,3 @@ class RichTextType extends AbstractType
         return 'richtext';
     }
 }
-
-class_alias(RichTextType::class, 'EzSystems\EzPlatformRichText\Form\Type\RichTextType');

--- a/src/lib/Persistence/Legacy/RichTextFieldValueConverter.php
+++ b/src/lib/Persistence/Legacy/RichTextFieldValueConverter.php
@@ -77,5 +77,3 @@ class RichTextFieldValueConverter implements Converter
         return 'sort_key_string';
     }
 }
-
-class_alias(RichTextFieldValueConverter::class, 'EzSystems\EzPlatformRichText\eZ\Persistence\Legacy\RichTextFieldValueConverter');

--- a/src/lib/REST/FieldTypeProcessor/RichTextProcessor.php
+++ b/src/lib/REST/FieldTypeProcessor/RichTextProcessor.php
@@ -39,5 +39,3 @@ class RichTextProcessor extends FieldTypeProcessor
         return $outgoingValueHash;
     }
 }
-
-class_alias(RichTextProcessor::class, 'EzSystems\EzPlatformRichText\eZ\REST\FieldTypeProcessor\RichTextProcessor');

--- a/src/lib/RichText/Converter/Aggregate.php
+++ b/src/lib/RichText/Converter/Aggregate.php
@@ -52,5 +52,3 @@ class Aggregate implements Converter
         $this->converters[] = $converter;
     }
 }
-
-class_alias(Aggregate::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Converter\Aggregate');

--- a/src/lib/RichText/Converter/Html5.php
+++ b/src/lib/RichText/Converter/Html5.php
@@ -23,5 +23,3 @@ class Html5 extends XsltConverter
         parent::__construct($stylesheet, $customStylesheets);
     }
 }
-
-class_alias(Html5::class, 'EzSystems\EzPlatformRichTextBundle\eZ\RichText\Converter\Html5');

--- a/src/lib/RichText/Converter/Html5Edit.php
+++ b/src/lib/RichText/Converter/Html5Edit.php
@@ -23,5 +23,3 @@ class Html5Edit extends XsltConverter
         parent::__construct($stylesheet, $customStylesheets);
     }
 }
-
-class_alias(Html5Edit::class, 'EzSystems\EzPlatformRichTextBundle\eZ\RichText\Converter\Html5Edit');

--- a/src/lib/RichText/Converter/Html5Input.php
+++ b/src/lib/RichText/Converter/Html5Input.php
@@ -23,5 +23,3 @@ class Html5Input extends XsltConverter
         parent::__construct($stylesheet, $customStylesheets);
     }
 }
-
-class_alias(Html5Input::class, 'EzSystems\EzPlatformRichTextBundle\eZ\RichText\Converter\Html5Input');

--- a/src/lib/RichText/Converter/Link.php
+++ b/src/lib/RichText/Converter/Link.php
@@ -150,5 +150,3 @@ class Link implements Converter
         return $urlAlias . $fragment;
     }
 }
-
-class_alias(Link::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Converter\Link');

--- a/src/lib/RichText/Converter/ProgramListing.php
+++ b/src/lib/RichText/Converter/ProgramListing.php
@@ -42,5 +42,3 @@ class ProgramListing implements Converter
         return $document;
     }
 }
-
-class_alias(ProgramListing::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Converter\ProgramListing');

--- a/src/lib/RichText/Converter/Render.php
+++ b/src/lib/RichText/Converter/Render.php
@@ -77,5 +77,3 @@ abstract class Render
         return $hash;
     }
 }
-
-class_alias(Render::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Converter\Render');

--- a/src/lib/RichText/Converter/Render/Embed.php
+++ b/src/lib/RichText/Converter/Render/Embed.php
@@ -340,5 +340,3 @@ class Embed extends Render implements Converter
         return $dataAttributes;
     }
 }
-
-class_alias(Embed::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Converter\Render\Embed');

--- a/src/lib/RichText/Converter/Render/Template.php
+++ b/src/lib/RichText/Converter/Render/Template.php
@@ -194,5 +194,3 @@ class Template extends Render implements Converter
         return $rootNode->appendChild($literalLayoutNode);
     }
 }
-
-class_alias(Template::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Converter\Render\Template');

--- a/src/lib/RichText/Converter/Xslt.php
+++ b/src/lib/RichText/Converter/Xslt.php
@@ -147,5 +147,3 @@ class Xslt extends XmlBase implements Converter
         return $document;
     }
 }
-
-class_alias(Xslt::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Converter\Xslt');

--- a/src/lib/RichText/ConverterDispatcher.php
+++ b/src/lib/RichText/ConverterDispatcher.php
@@ -75,5 +75,3 @@ class ConverterDispatcher
         throw new NotFoundException('Converter', $documentNamespace);
     }
 }
-
-class_alias(ConverterDispatcher::class, 'EzSystems\EzPlatformRichText\eZ\RichText\ConverterDispatcher');

--- a/src/lib/RichText/DOMDocumentFactory.php
+++ b/src/lib/RichText/DOMDocumentFactory.php
@@ -41,5 +41,3 @@ final class DOMDocumentFactory
         return $document;
     }
 }
-
-class_alias(DOMDocumentFactory::class, 'EzSystems\EzPlatformRichText\eZ\RichText\DOMDocumentFactory');

--- a/src/lib/RichText/Exception/InvalidXmlException.php
+++ b/src/lib/RichText/Exception/InvalidXmlException.php
@@ -43,5 +43,3 @@ class InvalidXmlException extends InvalidArgumentException
         return $this->errors;
     }
 }
-
-class_alias(InvalidXmlException::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Exception\InvalidXmlException');

--- a/src/lib/RichText/InputHandler.php
+++ b/src/lib/RichText/InputHandler.php
@@ -118,5 +118,3 @@ class InputHandler implements InputHandlerInterface
         return $this->docbookValidator->validateDocument($document);
     }
 }
-
-class_alias(InputHandler::class, 'EzSystems\EzPlatformRichText\eZ\RichText\InputHandler');

--- a/src/lib/RichText/Normalizer.php
+++ b/src/lib/RichText/Normalizer.php
@@ -31,5 +31,3 @@ abstract class Normalizer
      */
     abstract public function normalize($input);
 }
-
-class_alias(Normalizer::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Normalizer');

--- a/src/lib/RichText/Normalizer/Aggregate.php
+++ b/src/lib/RichText/Normalizer/Aggregate.php
@@ -62,5 +62,3 @@ class Aggregate extends Normalizer
         return $input;
     }
 }
-
-class_alias(Aggregate::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Normalizer\Aggregate');

--- a/src/lib/RichText/Normalizer/DocumentTypeDefinition.php
+++ b/src/lib/RichText/Normalizer/DocumentTypeDefinition.php
@@ -106,5 +106,3 @@ class DocumentTypeDefinition extends Normalizer
         return $this->expression;
     }
 }
-
-class_alias(DocumentTypeDefinition::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Normalizer\DocumentTypeDefinition');

--- a/src/lib/RichText/RelationProcessor.php
+++ b/src/lib/RichText/RelationProcessor.php
@@ -93,5 +93,3 @@ final class RelationProcessor
         ];
     }
 }
-
-class_alias(RelationProcessor::class, 'EzSystems\EzPlatformRichText\eZ\RichText\RelationProcessor');

--- a/src/lib/RichText/Renderer.php
+++ b/src/lib/RichText/Renderer.php
@@ -487,5 +487,3 @@ class Renderer implements RendererInterface
         return $location;
     }
 }
-
-class_alias(Renderer::class, 'EzSystems\EzPlatformRichTextBundle\eZ\RichText\Renderer');

--- a/src/lib/RichText/Validator/CustomTagsValidator.php
+++ b/src/lib/RichText/Validator/CustomTagsValidator.php
@@ -101,5 +101,3 @@ class CustomTagsValidator implements ValidatorInterface
         return $errors;
     }
 }
-
-class_alias(CustomTagsValidator::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Validator\CustomTagsValidator');

--- a/src/lib/RichText/Validator/InternalLinkValidator.php
+++ b/src/lib/RichText/Validator/InternalLinkValidator.php
@@ -147,5 +147,3 @@ class InternalLinkValidator implements ValidatorInterface
         return "//docbook:{$tagName}[starts-with(@xlink:href, 'ezcontent://') or starts-with(@xlink:href, 'ezlocation://') or starts-with(@xlink:href, 'ezremote://')]";
     }
 }
-
-class_alias(InternalLinkValidator::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Validator\InternalLinkValidator');

--- a/src/lib/RichText/Validator/Validator.php
+++ b/src/lib/RichText/Validator/Validator.php
@@ -153,5 +153,3 @@ class Validator extends XmlBase implements ValidatorInterface
         return (strlen($location) ? $location . ': ' : '') . $failedAssert->textContent;
     }
 }
-
-class_alias(Validator::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Validator\Validator');

--- a/src/lib/RichText/Validator/ValidatorAggregate.php
+++ b/src/lib/RichText/Validator/ValidatorAggregate.php
@@ -40,5 +40,3 @@ class ValidatorAggregate implements ValidatorInterface
         return $validationErrors;
     }
 }
-
-class_alias(ValidatorAggregate::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Validator\ValidatorAggregate');

--- a/src/lib/RichText/Validator/ValidatorDispatcher.php
+++ b/src/lib/RichText/Validator/ValidatorDispatcher.php
@@ -83,5 +83,3 @@ class ValidatorDispatcher implements ValidatorInterface
         return $this->dispatch($xmlDocument);
     }
 }
-
-class_alias(ValidatorDispatcher::class, 'EzSystems\EzPlatformRichText\eZ\RichText\Validator\ValidatorDispatcher');

--- a/src/lib/RichText/XmlBase.php
+++ b/src/lib/RichText/XmlBase.php
@@ -115,5 +115,3 @@ abstract class XmlBase
         return $errors;
     }
 }
-
-class_alias(XmlBase::class, 'EzSystems\EzPlatformRichText\eZ\RichText\XmlBase');

--- a/src/lib/Translation/Extractor/OnlineEditorCustomAttributesExtractor.php
+++ b/src/lib/Translation/Extractor/OnlineEditorCustomAttributesExtractor.php
@@ -111,5 +111,3 @@ final class OnlineEditorCustomAttributesExtractor implements ExtractorInterface
         }
     }
 }
-
-class_alias(OnlineEditorCustomAttributesExtractor::class, 'EzSystems\EzPlatformRichText\Translation\Extractor\OnlineEditorCustomAttributesExtractor');

--- a/src/lib/Validator/Constraints/RichText.php
+++ b/src/lib/Validator/Constraints/RichText.php
@@ -17,5 +17,3 @@ class RichText extends Constraint
 {
     public $message = 'Invalid value';
 }
-
-class_alias(RichText::class, 'EzSystems\EzPlatformRichText\Validator\Constraints\RichText');

--- a/src/lib/Validator/Constraints/RichTextValidator.php
+++ b/src/lib/Validator/Constraints/RichTextValidator.php
@@ -53,5 +53,3 @@ class RichTextValidator extends ConstraintValidator
         }
     }
 }
-
-class_alias(RichTextValidator::class, 'EzSystems\EzPlatformRichText\Validator\Constraints\RichTextValidator');

--- a/tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
@@ -67,5 +67,3 @@ class RichTextHtml5ConverterPassTest extends AbstractCompilerPassTestCase
         );
     }
 }
-
-class_alias(RichTextHtml5ConverterPassTest::class, 'EzSystems\Tests\EzPlatformRichTextBundle\DependencyInjection\Compiler\RichTextHtml5ConverterPassTest');

--- a/tests/bundle/DependencyInjection/Configuration/ConfigurationTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/ConfigurationTest.php
@@ -130,5 +130,3 @@ final class ConfigurationTest extends TestCase
         $this->assertProcessedConfigurationEquals($configurationValues, $expectedProcessedConfiguration);
     }
 }
-
-class_alias(ConfigurationTest::class, 'EzSystems\Tests\EzPlatformRichTextBundle\DependencyInjection\Configuration\ConfigurationTest');

--- a/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -414,5 +414,3 @@ class RichTextTest extends AbstractParserTestCase
         ];
     }
 }
-
-class_alias(RichTextTest::class, 'EzSystems\Tests\EzPlatformRichTextBundle\DependencyInjection\Configuration\Parser\FieldType\RichTextTest');

--- a/tests/bundle/DependencyInjection/IbexaFieldTypeRichTextExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaFieldTypeRichTextExtensionTest.php
@@ -165,5 +165,3 @@ class IbexaFieldTypeRichTextExtensionTest extends AbstractExtensionTestCase
         ];
     }
 }
-
-class_alias(IbexaFieldTypeRichTextExtensionTest::class, 'EzSystems\Tests\EzPlatformRichTextBundle\DependencyInjection\IbexaFieldTypeRichTextExtensionTest');

--- a/tests/bundle/Templating/Twig/Extension/YoutubeIdExtractorExtensionTest.php
+++ b/tests/bundle/Templating/Twig/Extension/YoutubeIdExtractorExtensionTest.php
@@ -67,5 +67,3 @@ class YoutubeIdExtractorExtensionTest extends TestCase
         self::assertEquals('ibexa_richtext_youtube_extract_id', $result[0]->getName());
     }
 }
-
-class_alias(YoutubeIdExtractorExtensionTest::class, 'EzSystems\Tests\EzPlatformRichTextBundle\Templating\Twig\Extension\YoutubeIdExtractorExtensionTest');

--- a/tests/lib/Configuration/AggregateProviderTest.php
+++ b/tests/lib/Configuration/AggregateProviderTest.php
@@ -88,5 +88,3 @@ class AggregateProviderTest extends TestCase
         ];
     }
 }
-
-class_alias(AggregateProviderTest::class, 'EzSystems\Tests\EzPlatformRichText\Configuration\AggregateProviderTest');

--- a/tests/lib/Configuration/Provider/AlloyEditorTest.php
+++ b/tests/lib/Configuration/Provider/AlloyEditorTest.php
@@ -224,5 +224,3 @@ class AlloyEditorTest extends BaseProviderTestCase
         };
     }
 }
-
-class_alias(AlloyEditorTest::class, 'EzSystems\Tests\EzPlatformRichText\Configuration\Provider\AlloyEditorTest');

--- a/tests/lib/Configuration/Provider/BaseCustomTemplateProviderTestCase.php
+++ b/tests/lib/Configuration/Provider/BaseCustomTemplateProviderTestCase.php
@@ -59,5 +59,3 @@ abstract class BaseCustomTemplateProviderTestCase extends BaseProviderTestCase
         );
     }
 }
-
-class_alias(BaseCustomTemplateProviderTestCase::class, 'EzSystems\Tests\EzPlatformRichText\Configuration\Provider\BaseCustomTemplateProviderTestCase');

--- a/tests/lib/Configuration/Provider/BaseProviderTestCase.php
+++ b/tests/lib/Configuration/Provider/BaseProviderTestCase.php
@@ -37,5 +37,3 @@ abstract class BaseProviderTestCase extends TestCase
         );
     }
 }
-
-class_alias(BaseProviderTestCase::class, 'EzSystems\Tests\EzPlatformRichText\Configuration\Provider\BaseProviderTestCase');

--- a/tests/lib/Configuration/Provider/CKEditorTest.php
+++ b/tests/lib/Configuration/Provider/CKEditorTest.php
@@ -459,5 +459,3 @@ final class CKEditorTest extends BaseProviderTestCase
         };
     }
 }
-
-class_alias(CKEditorTest::class, 'EzSystems\Tests\EzPlatformRichText\Configuration\Provider\CKEditorTest');

--- a/tests/lib/Configuration/Provider/CustomStyleProviderTest.php
+++ b/tests/lib/Configuration/Provider/CustomStyleProviderTest.php
@@ -33,5 +33,3 @@ class CustomStyleProviderTest extends BaseCustomTemplateProviderTestCase
         return 'fieldtypes.ezrichtext.custom_styles';
     }
 }
-
-class_alias(CustomStyleProviderTest::class, 'EzSystems\Tests\EzPlatformRichText\Configuration\Provider\CustomStyleProviderTest');

--- a/tests/lib/Configuration/Provider/CustomTagProviderTest.php
+++ b/tests/lib/Configuration/Provider/CustomTagProviderTest.php
@@ -33,5 +33,3 @@ class CustomTagProviderTest extends BaseCustomTemplateProviderTestCase
         return 'fieldtypes.ezrichtext.custom_tags';
     }
 }
-
-class_alias(CustomTagProviderTest::class, 'EzSystems\Tests\EzPlatformRichText\Configuration\Provider\CustomTagProviderTest');

--- a/tests/lib/Configuration/UI/Config/Mapper/CustomTagTest.php
+++ b/tests/lib/Configuration/UI/Config/Mapper/CustomTagTest.php
@@ -225,5 +225,3 @@ class CustomTagTest extends TestCase
         return $packagesMock;
     }
 }
-
-class_alias(CustomTagTest::class, 'EzSystems\Tests\EzPlatformRichText\Configuration\UI\Config\Mapper\CustomTagTest');

--- a/tests/lib/Configuration/UI/Config/Mapper/OnlineEditorTest.php
+++ b/tests/lib/Configuration/UI/Config/Mapper/OnlineEditorTest.php
@@ -215,5 +215,3 @@ class OnlineEditorTest extends TestCase
         );
     }
 }
-
-class_alias(OnlineEditorTest::class, 'EzSystems\Tests\EzPlatformRichText\Configuration\UI\Config\Mapper\OnlineEditorTest');

--- a/tests/lib/FieldType/RichText/Gateway/DoctrineStorageTest.php
+++ b/tests/lib/FieldType/RichText/Gateway/DoctrineStorageTest.php
@@ -59,5 +59,3 @@ class DoctrineStorageTest extends TestCase
         return $this->storageGateway;
     }
 }
-
-class_alias(DoctrineStorageTest::class, 'EzSystems\Tests\EzPlatformRichText\FieldType\RichText\Gateway\DoctrineStorageTest');

--- a/tests/lib/FieldType/RichText/RichTextStorageTest.php
+++ b/tests/lib/FieldType/RichText/RichTextStorageTest.php
@@ -433,5 +433,3 @@ class RichTextStorageTest extends TestCase
         return $this->gatewayMock;
     }
 }
-
-class_alias(RichTextStorageTest::class, 'EzSystems\Tests\EzPlatformRichText\FieldType\RichText\RichTextStorageTest');

--- a/tests/lib/FieldType/RichText/SearchFieldTest.php
+++ b/tests/lib/FieldType/RichText/SearchFieldTest.php
@@ -135,5 +135,3 @@ XML;
         return '<?xml version="1.0" encoding="UTF-8"?><section></section>';
     }
 }
-
-class_alias(SearchFieldTest::class, 'EzSystems\Tests\EzPlatformRichText\FieldType\RichText\SearchFieldTest');

--- a/tests/lib/FieldType/RichTextTest.php
+++ b/tests/lib/FieldType/RichTextTest.php
@@ -465,5 +465,3 @@ EOT;
         return [];
     }
 }
-
-class_alias(RichTextTest::class, 'EzSystems\Tests\EzPlatformRichText\FieldType\RichTextTest');

--- a/tests/lib/Form/DataTransformer/RichTextTransformerTest.php
+++ b/tests/lib/Form/DataTransformer/RichTextTransformerTest.php
@@ -139,5 +139,3 @@ class RichTextTransformerTest extends TestCase
         ];
     }
 }
-
-class_alias(RichTextTransformerTest::class, 'EzSystems\Tests\EzPlatformRichText\Form\DataTransformer\RichTextTransformerTest');

--- a/tests/lib/Persistence/Legacy/Tests/Content/FieldValue/Converter/RichTextFieldValueConverterTest.php
+++ b/tests/lib/Persistence/Legacy/Tests/Content/FieldValue/Converter/RichTextFieldValueConverterTest.php
@@ -77,5 +77,3 @@ EOT;
         self::assertSame($this->docbookString, $fieldValue->data);
     }
 }
-
-class_alias(RichTextFieldValueConverterTest::class, 'EzSystems\EzPlatformRichText\Persistence\Legacy\Tests\Content\FieldValue\Converter\RichTextFieldValueConverterTest');

--- a/tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php
+++ b/tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php
@@ -68,5 +68,3 @@ EOT;
         return new RichTextProcessor($this->converter);
     }
 }
-
-class_alias(RichTextProcessorTest::class, 'EzSystems\Tests\EzPlatformRichText\REST\FieldTypeProcessor\RichTextProcessorTest');

--- a/tests/lib/RichText/Converter/AggregateTest.php
+++ b/tests/lib/RichText/Converter/AggregateTest.php
@@ -98,5 +98,3 @@ class AggregateTest extends TestCase
         ];
     }
 }
-
-class_alias(AggregateTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Converter\AggregateTest');

--- a/tests/lib/RichText/Converter/LinkTest.php
+++ b/tests/lib/RichText/Converter/LinkTest.php
@@ -559,5 +559,3 @@ class LinkTest extends TestCase
         self::assertEquals($expectedOutputDocument, $outputDocument);
     }
 }
-
-class_alias(LinkTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Converter\LinkTest');

--- a/tests/lib/RichText/Converter/Render/EmbedTest.php
+++ b/tests/lib/RichText/Converter/Render/EmbedTest.php
@@ -885,5 +885,3 @@ class EmbedTest extends TestCase
         return $this->createMock(LoggerInterface::class);
     }
 }
-
-class_alias(EmbedTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Converter\Render\EmbedTest');

--- a/tests/lib/RichText/Converter/Render/TemplateTest.php
+++ b/tests/lib/RichText/Converter/Render/TemplateTest.php
@@ -352,5 +352,3 @@ class TemplateTest extends TestCase
         ],
     ];
 }
-
-class_alias(TemplateTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Converter\Render\TemplateTest');

--- a/tests/lib/RichText/Converter/Xslt/BaseTest.php
+++ b/tests/lib/RichText/Converter/Xslt/BaseTest.php
@@ -280,5 +280,3 @@ abstract class BaseTest extends TestCase
         return [];
     }
 }
-
-class_alias(BaseTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Converter\Xslt\BaseTest');

--- a/tests/lib/RichText/Converter/Xslt/DebugRenderer.php
+++ b/tests/lib/RichText/Converter/Xslt/DebugRenderer.php
@@ -78,5 +78,3 @@ final class DebugRenderer implements RendererInterface
         return $isInline ? 'true' : 'false';
     }
 }
-
-class_alias(DebugRenderer::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Converter\Xslt\DebugRenderer');

--- a/tests/lib/RichText/Converter/Xslt/DocbookToXhtml5EditTest.php
+++ b/tests/lib/RichText/Converter/Xslt/DocbookToXhtml5EditTest.php
@@ -84,5 +84,3 @@ class DocbookToXhtml5EditTest extends BaseTest
         ];
     }
 }
-
-class_alias(DocbookToXhtml5EditTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Converter\Xslt\DocbookToXhtml5EditTest');

--- a/tests/lib/RichText/Converter/Xslt/DocbookToXhtml5OutputTest.php
+++ b/tests/lib/RichText/Converter/Xslt/DocbookToXhtml5OutputTest.php
@@ -112,5 +112,3 @@ class DocbookToXhtml5OutputTest extends BaseTest
         return $this->converter;
     }
 }
-
-class_alias(DocbookToXhtml5OutputTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Converter\Xslt\DocbookToXhtml5OutputTest');

--- a/tests/lib/RichText/Converter/Xslt/Xhtml5ToDocbookTest.php
+++ b/tests/lib/RichText/Converter/Xslt/Xhtml5ToDocbookTest.php
@@ -119,5 +119,3 @@ class Xhtml5ToDocbookTest extends BaseTest
         return $this->converter;
     }
 }
-
-class_alias(Xhtml5ToDocbookTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Converter\Xslt\Xhtml5ToDocbookTest');

--- a/tests/lib/RichText/DOMDocumentFactoryTest.php
+++ b/tests/lib/RichText/DOMDocumentFactoryTest.php
@@ -56,5 +56,3 @@ EOT;
         $this->domDocumentFactory->loadXMLString('This is not XML');
     }
 }
-
-class_alias(DOMDocumentFactoryTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\DOMDocumentFactoryTest');

--- a/tests/lib/RichText/InputHandlerTest.php
+++ b/tests/lib/RichText/InputHandlerTest.php
@@ -228,5 +228,3 @@ EOT;
         self::assertEquals($expectedErrors, $actualErrors);
     }
 }
-
-class_alias(InputHandlerTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\InputHandlerTest');

--- a/tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
+++ b/tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
@@ -217,5 +217,3 @@ XML
         return new DocumentTypeDefinition($documentElement, $namespace, $dtdPath);
     }
 }
-
-class_alias(DocumentTypeDefinitionTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Normalizer\DocumentTypeDefinitionTest');

--- a/tests/lib/RichText/RelationProcessorTest.php
+++ b/tests/lib/RichText/RelationProcessorTest.php
@@ -74,5 +74,3 @@ EOT;
         return $document;
     }
 }
-
-class_alias(RelationProcessorTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\RelationProcessorTest');

--- a/tests/lib/RichText/RendererTest.php
+++ b/tests/lib/RichText/RendererTest.php
@@ -1811,5 +1811,3 @@ class RendererTest extends TestCase
         return $contentMock;
     }
 }
-
-class_alias(RendererTest::class, 'EzSystems\Tests\EzPlatformRichTextBundle\eZ\RichText\RendererTest');

--- a/tests/lib/RichText/Validator/CustomTagsValidatorTest.php
+++ b/tests/lib/RichText/Validator/CustomTagsValidatorTest.php
@@ -229,5 +229,3 @@ DOCBOOK
         return $document;
     }
 }
-
-class_alias(CustomTagsValidatorTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Validator\CustomTagsValidatorTest');

--- a/tests/lib/RichText/Validator/DocbookTest.php
+++ b/tests/lib/RichText/Validator/DocbookTest.php
@@ -201,5 +201,3 @@ class DocbookTest extends TestCase
         ];
     }
 }
-
-class_alias(DocbookTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Validator\DocbookTest');

--- a/tests/lib/RichText/Validator/InternalLinkValidatorTest.php
+++ b/tests/lib/RichText/Validator/InternalLinkValidatorTest.php
@@ -316,5 +316,3 @@ class InternalLinkValidatorTest extends TestCase
         return $doc;
     }
 }
-
-class_alias(InternalLinkValidatorTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Validator\InternalLinkValidatorTest');

--- a/tests/lib/RichText/Validator/ValidatorAggregateTest.php
+++ b/tests/lib/RichText/Validator/ValidatorAggregateTest.php
@@ -45,5 +45,3 @@ class ValidatorAggregateTest extends TestCase
         self::assertEquals($expectedErrors, $actualErrors);
     }
 }
-
-class_alias(ValidatorAggregateTest::class, 'EzSystems\Tests\EzPlatformRichText\RichText\Validator\ValidatorAggregateTest');

--- a/tests/lib/Validator/Constraints/RichTextValidatorTest.php
+++ b/tests/lib/Validator/Constraints/RichTextValidatorTest.php
@@ -142,5 +142,3 @@ class RichTextValidatorTest extends TestCase
         }, $errors);
     }
 }
-
-class_alias(RichTextValidatorTest::class, 'EzSystems\Tests\EzPlatformRichText\Validator\Constraints\RichTextValidatorTest');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `class_alias` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
