### PR TITLE
IBX-8340: RichText: Not possible to create a link to a custom route

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/link/ui/link-form-view.js
+++ b/src/bundle/Resources/public/js/CKEditor/link/ui/link-form-view.js
@@ -208,7 +208,7 @@ class IbexaLinkFormView extends View {
         const relativeLinkPrefix = '/';
         const schemaPattern = /^[a-z0-9]+:\/?\/?/i;
         const isAnchor = href.indexOf(anchorPrefix) === 0;
-        const isRelativeLink = href.indexOf(relativeLinkPrefix) === 0;
+        const isRelativeLink = href.startsWith(relativeLinkPrefix);
         const isLocation = schemaPattern.test(href);
 
         if (isAnchor || isLocation || isRelativeLink) {

--- a/src/bundle/Resources/public/js/CKEditor/link/ui/link-form-view.js
+++ b/src/bundle/Resources/public/js/CKEditor/link/ui/link-form-view.js
@@ -205,11 +205,13 @@ class IbexaLinkFormView extends View {
         }
 
         const anchorPrefix = '#';
+        const relativeLinkPrefix = '/';
         const schemaPattern = /^[a-z0-9]+:\/?\/?/i;
         const isAnchor = href.indexOf(anchorPrefix) === 0;
+        const isRelativeLink = href.indexOf(relativeLinkPrefix) === 0;
         const isLocation = schemaPattern.test(href);
 
-        if (isAnchor || isLocation) {
+        if (isAnchor || isLocation || isRelativeLink) {
             return href;
         }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8340 |
|----------------|-----------|

#### Description:
It's not possible to create a link to a custom route. In the link modal:
- Entering "link" sends "http://link/" to the back-end
- Entering "/link" sends "[http:///link"](http://link/) to the back-end

 
New editor should behave in the same way as the old one (alloy) in 3.3:
- Entering "link" sends "http://link/" to the back-end
- Entering "/link" sends "[/link"](http://link/) to the back-end

Links will not be site-access aware ( so `/foobar ` won't be translated to `/admin/foobar` or `/pl/foobar`) but this was not the case in 3.3 either

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
