### PR TITLE
IBX-8363: Corrected namespace for RichTextFieldValueConverterTest and added return types

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2039,16 +2039,6 @@ parameters:
 			path: tests/lib/Form/DataTransformer/RichTextTransformerTest.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Persistence\\\\Legacy\\\\Tests\\\\Content\\\\FieldValue\\\\Converter\\\\RichTextFieldValueConverterTest\\:\\:testToFieldValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Persistence/Legacy/Tests/Content/FieldValue/Converter/RichTextFieldValueConverterTest.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Persistence\\\\Legacy\\\\Tests\\\\Content\\\\FieldValue\\\\Converter\\\\RichTextFieldValueConverterTest\\:\\:testToStorageValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Persistence/Legacy/Tests/Content/FieldValue/Converter/RichTextFieldValueConverterTest.php
-
-		-
 			message: "#^Call to method expects\\(\\) on an unknown class Ibexa\\\\FieldTypeRichText\\\\RichText\\\\Converter\\.$#"
 			count: 1
 			path: tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php

--- a/tests/lib/Persistence/Legacy/Tests/Content/FieldValue/Converter/RichTextFieldValueConverterTest.php
+++ b/tests/lib/Persistence/Legacy/Tests/Content/FieldValue/Converter/RichTextFieldValueConverterTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\FieldTypeRichText\Persistence\Legacy\Tests\Content\FieldValue\Converter;
+namespace Ibexa\Tests\FieldTypeRichText\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 
 use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Core\Persistence\Legacy\Content\StorageFieldValue;
@@ -54,7 +54,7 @@ EOT;
     /**
      * @covers \Ibexa\FieldTypeRichText\Persistence\Legacy\RichTextFieldValueConverter::toStorageValue
      */
-    public function testToStorageValue()
+    public function testToStorageValue(): void
     {
         $value = new FieldValue();
         $value->data = $this->docbookString;
@@ -67,7 +67,7 @@ EOT;
     /**
      * @covers \Ibexa\FieldTypeRichText\Persistence\Legacy\RichTextFieldValueConverter::toFieldValue
      */
-    public function testToFieldValue()
+    public function testToFieldValue(): void
     {
         $storageFieldValue = new StorageFieldValue();
         $storageFieldValue->dataText = $this->docbookString;


### PR DESCRIPTION
| :ticket: Issue | IBX-8363 |
|----------------|-----------|


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
