### PR TITLE
IBX-8150: Added option to enable attributes types

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -46,7 +46,7 @@ class Configuration extends SiteAccessConfiguration
         return $treeBuilder;
     }
 
-    private function addEnabledAttributeTypesSection(NodeBuilder $richTextNode)
+    private function addEnabledAttributeTypesSection(NodeBuilder $richTextNode): NodeBuilder
     {
         return $richTextNode
                 ->arrayNode('enabled_attribute_types')

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -74,7 +74,7 @@ class Configuration extends SiteAccessConfiguration
                                     'The value "%s" is not allowed for path "ibexa_fieldtype_richtext.custom_tags.%s.attributes.campaign.type". Allowed values: %s',
                                     $attribute['type'],
                                     $tagIdentifier,
-                                    implode(', ', array_map(static fn ($type) => "\"$type\"", $enabledTypes))
+                                    implode(', ', array_map(static fn ($type): string => "\"$type\"", $enabledTypes))
                                 )
                             );
                         }

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -71,7 +71,7 @@ class Configuration extends SiteAccessConfiguration
                         if (!in_array($attribute['type'], $enabledTypes, true)) {
                             throw new InvalidConfigurationException(
                                 sprintf(
-                                    'The value "%s" is not allowed for path "ibexa_fieldtype_richtext.custom_tags.%s.attributes.campaign.type". Permissible values: %s',
+                                    'The value "%s" is not allowed for path "ibexa_fieldtype_richtext.custom_tags.%s.attributes.campaign.type". Allowed values: %s',
                                     $attribute['type'],
                                     $tagIdentifier,
                                     implode(', ', array_map(static fn ($type) => "\"$type\"", $enabledTypes))

--- a/tests/bundle/DependencyInjection/Configuration/ConfigurationTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/ConfigurationTest.php
@@ -73,6 +73,7 @@ final class ConfigurationTest extends TestCase
                 [
                     'custom_tags' => [],
                     'custom_styles' => [],
+                    'enabled_attribute_types' => ['number', 'string', 'boolean', 'choice', 'link'],
                 ],
             ],
             'Alloy editor configs from multiple sources' => [
@@ -111,6 +112,7 @@ final class ConfigurationTest extends TestCase
                     ],
                     'custom_tags' => [],
                     'custom_styles' => [],
+                    'enabled_attribute_types' => ['number', 'string', 'boolean', 'choice', 'link'],
                 ],
             ],
         ];

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/000-attribute-type-number.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/000-attribute-type-number.yaml
@@ -9,3 +9,9 @@ custom_tags:
                 default_value: 360
         is_inline: false
 custom_styles: []
+enabled_attribute_types:
+    - 'number'
+    - 'string'
+    - 'boolean'
+    - 'choice'
+    - 'link'

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/001-attribute-type-string.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/001-attribute-type-string.yaml
@@ -9,3 +9,9 @@ custom_tags:
                 default_value: 'abc'
         is_inline: false
 custom_styles: []
+enabled_attribute_types:
+    - 'number'
+    - 'string'
+    - 'boolean'
+    - 'choice'
+    - 'link'

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/002-attribute-type-boolean.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/002-attribute-type-boolean.yaml
@@ -9,3 +9,9 @@ custom_tags:
                 default_value: ~
         is_inline: false
 custom_styles: []
+enabled_attribute_types:
+    - 'number'
+    - 'string'
+    - 'boolean'
+    - 'choice'
+    - 'link'

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/003-attribute-type-choice.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/003-attribute-type-choice.yaml
@@ -10,3 +10,9 @@ custom_tags:
                 choices: ['choice-1', 'choice-2']
         is_inline: false
 custom_styles: []
+enabled_attribute_types:
+    - 'number'
+    - 'string'
+    - 'boolean'
+    - 'choice'
+    - 'link'

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/004-attribute-type-link.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/004-attribute-type-link.yaml
@@ -9,3 +9,9 @@ custom_tags:
                 default_value: ~
         is_inline: false
 custom_styles: []
+enabled_attribute_types:
+    - 'number'
+    - 'string'
+    - 'boolean'
+    - 'choice'
+    - 'link'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-8150](https://issues.ibexa.co/browse/IBX-8150)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | 4.6
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes/no

Recipes level configuration:
https://github.com/ibexa/recipes-dev/pull/123/files

### Example configuration, in `packages/ibexa_richtext.yaml` if i.e. you want to have choice field disabled:

```
ibexa_fieldtype_richtext:
    enabled_attribute_types:
        - number
        - string
        - boolean
        - link
```

### QA

To test this, feel free to remove one of the custom tag from allowed list - configuration should then fail same way as using not existing custom tag type.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
