### PR TITLE
IBX-8434: Added ProviderConfiguratorInterface to allow configuration post-processing

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1314,7 +1314,10 @@ parameters:
 			message: "#^Cannot access property \\$id on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Field\\|null\\.$#"
 			count: 1
 			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
+		-
+			message: "#^Cannot call method fetchOne\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
+			count: 1
+			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
 		-
 			message: "#^Cannot access property \\$value on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Field\\|null\\.$#"
 			count: 1
@@ -1327,11 +1330,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: "#^Cannot call method fetchOne\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
 			count: 1
 			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -316,16 +316,6 @@ parameters:
 			path: src/lib/Configuration/Provider/CustomStyle.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\Provider\\\\CustomTag\\:\\:getConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/Provider/CustomTag.php
-
-		-
-			message: "#^Property Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\Provider\\\\CustomTag\\:\\:\\$customTagConfigurationMapper \\(Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\) does not accept Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTemplateConfigMapper\\.$#"
-			count: 1
-			path: src/lib/Configuration/Provider/CustomTag.php
-
-		-
 			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomStyle\\:\\:__construct\\(\\) has parameter \\$customStylesConfiguration with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Configuration/UI/Mapper/CustomStyle.php
@@ -349,76 +339,6 @@ parameters:
 			message: "#^Property Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomStyle\\:\\:\\$packages is never read, only written\\.$#"
 			count: 1
 			path: src/lib/Configuration/UI/Mapper/CustomStyle.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\:\\:__construct\\(\\) has parameter \\$customTagAttributeMappers with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\:\\:__construct\\(\\) has parameter \\$customTagsConfiguration with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\:\\:mapConfig\\(\\) has parameter \\$enabledCustomTags with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\:\\:mapConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\:\\:translateLabels\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\:\\:translateLabels\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag.php
-
-		-
-			message: "#^Property Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\:\\:\\$customTagAttributeMappers \\(array\\<Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\\\AttributeMapper\\>\\) does not accept Traversable\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag.php
-
-		-
-			message: "#^Property Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\:\\:\\$customTagsConfiguration type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\\\AttributeMapper\\:\\:mapConfig\\(\\) has parameter \\$customTagAttributeProperties with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag/AttributeMapper.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\\\AttributeMapper\\:\\:mapConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag/AttributeMapper.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\\\ChoiceAttributeMapper\\:\\:mapConfig\\(\\) has parameter \\$customTagAttributeProperties with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag/ChoiceAttributeMapper.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\\\ChoiceAttributeMapper\\:\\:mapConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag/ChoiceAttributeMapper.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\\\CommonAttributeMapper\\:\\:mapConfig\\(\\) has parameter \\$customTagAttributeProperties with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag/CommonAttributeMapper.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTag\\\\CommonAttributeMapper\\:\\:mapConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Configuration/UI/Mapper/CustomTag/CommonAttributeMapper.php
 
 		-
 			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Configuration\\\\UI\\\\Mapper\\\\CustomTemplateConfigMapper\\:\\:mapConfig\\(\\) has parameter \\$enabledCustomTemplates with no value type specified in iterable type array\\.$#"
@@ -1394,10 +1314,7 @@ parameters:
 			message: "#^Cannot access property \\$id on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Field\\|null\\.$#"
 			count: 1
 			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-		-
-			message: "#^Cannot call method fetchOne\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
+
 		-
 			message: "#^Cannot access property \\$value on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Field\\|null\\.$#"
 			count: 1
@@ -1410,6 +1327,11 @@ parameters:
 
 		-
 			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
+			count: 1
+			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
+
+		-
+			message: "#^Cannot call method fetchOne\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
 			count: 1
 			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
 

--- a/src/bundle/Resources/config/configuration.yaml
+++ b/src/bundle/Resources/config/configuration.yaml
@@ -15,17 +15,41 @@ services:
         arguments:
             $customStyleConfigurationMapper: '@Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomStyle'
 
+    ibexa.field_type_rich_text.configuration.provider.custom_style.configurable:
+        class: Ibexa\FieldTypeRichText\Configuration\Provider\ConfigurableProvider
+        decorates: Ibexa\FieldTypeRichText\Configuration\Provider\CustomStyle
+        arguments:
+            $configurators: !tagged_iterator ibexa.field_type.richtext.configuration.custom_style.configurator
+
     Ibexa\FieldTypeRichText\Configuration\Provider\CustomTag:
         arguments:
             $customTagConfigurationMapper: '@Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag'
+
+    ibexa.field_type_rich_text.configuration.provider.custom_tag.configurable:
+        class: Ibexa\FieldTypeRichText\Configuration\Provider\ConfigurableProvider
+        decorates: Ibexa\FieldTypeRichText\Configuration\Provider\CustomTag
+        arguments:
+            $configurators: !tagged_iterator ibexa.field_type.richtext.configuration.custom_tag.configurator
 
     Ibexa\FieldTypeRichText\Configuration\Provider\AlloyEditor:
         arguments:
             $alloyEditorConfiguration: '%ibexa.field_type.richtext.alloy_editor%'
 
+    ibexa.field_type_rich_text.configuration.provider.alloy_editor.configurable:
+        class: Ibexa\FieldTypeRichText\Configuration\Provider\ConfigurableProvider
+        decorates: Ibexa\FieldTypeRichText\Configuration\Provider\AlloyEditor
+        arguments:
+            $configurators: !tagged_iterator ibexa.field_type.richtext.configuration.alloy_editor.configurator
+
     Ibexa\FieldTypeRichText\Configuration\Provider\CKEditor:
         arguments:
             $customStylesConfiguration: '%ibexa.field_type.richtext.custom_styles%'
+
+    ibexa.field_type_rich_text.configuration.provider.ck_editor.configurable:
+        class: Ibexa\FieldTypeRichText\Configuration\Provider\ConfigurableProvider
+        decorates: Ibexa\FieldTypeRichText\Configuration\Provider\CKEditor
+        arguments:
+            $configurators: !tagged_iterator ibexa.field_type.richtext.configuration.ck_editor.configurator
 
     Ibexa\FieldTypeRichText\Configuration\AggregateProvider:
         arguments:

--- a/src/bundle/Resources/config/ui/mappers.yaml
+++ b/src/bundle/Resources/config/ui/mappers.yaml
@@ -26,7 +26,7 @@ services:
             $customTagsConfiguration: '%ibexa.field_type.richtext.custom_tags%'
             $translatorBag: '@translator'
             $translationDomain: '%ibexa.field_type.richtext.custom_tags.translation_domain%'
-            $customTagAttributeMappers: !tagged ibexa.field_type.richtext.configuration.custom_tag.mapper
+            $customTagAttributeMappers: !tagged_iterator ibexa.field_type.richtext.configuration.custom_tag.mapper
 
     # RichText Custom Styles UI config mapper
     Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomStyle:

--- a/src/contracts/Configuration/ProviderConfiguratorInterface.php
+++ b/src/contracts/Configuration/ProviderConfiguratorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\FieldTypeRichText\Configuration;
+
+interface ProviderConfiguratorInterface
+{
+    /**
+     * @param array<string, mixed> $configuration
+     *
+     * @return array<string, mixed>
+     */
+    public function getConfiguration(array $configuration): array;
+}

--- a/src/lib/Configuration/Provider/ConfigurableProvider.php
+++ b/src/lib/Configuration/Provider/ConfigurableProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\FieldTypeRichText\Configuration\Provider;
+
+use Ibexa\Contracts\FieldTypeRichText\Configuration\Provider;
+
+final class ConfigurableProvider implements Provider
+{
+    private Provider $inner;
+
+    /** @var iterable<\Ibexa\Contracts\FieldTypeRichText\Configuration\ProviderConfiguratorInterface> */
+    private iterable $configurators;
+
+    /**
+     * @param iterable<\Ibexa\Contracts\FieldTypeRichText\Configuration\ProviderConfiguratorInterface> $configurators
+     */
+    public function __construct(
+        Provider $inner,
+        iterable $configurators
+    ) {
+        $this->inner = $inner;
+        $this->configurators = $configurators;
+    }
+
+    public function getName(): string
+    {
+        return $this->inner->getName();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfiguration(): array
+    {
+        $configuration = $this->inner->getConfiguration();
+        foreach ($this->configurators as $configurator) {
+            $configuration = $configurator->getConfiguration($configuration);
+        }
+
+        return $configuration;
+    }
+}

--- a/src/lib/Configuration/Provider/CustomTag.php
+++ b/src/lib/Configuration/Provider/CustomTag.php
@@ -16,14 +16,28 @@ use Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTemplateConfigMapper;
  * Custom Tags configuration provider.
  *
  * @internal For internal use by RichText package
+ *
+ * @phpstan-type TConfigOutput array{
+ *     label: string,
+ *     description: string,
+ *     isInline: bool,
+ *     icon?: string,
+ *     attributes?: array<string, TConfigAttributeOutput>
+ * }
+ * @phpstan-type TConfigAttributeOutput array{
+ *     type: string,
+ *     required: bool,
+ *     defaultValue: mixed,
+ *     label: string,
+ *     choices?: array<string>,
+ *     choicesLabel?: array<string, string>,
+ * }
  */
 final class CustomTag implements Provider
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /** @var \Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag */
-    private $customTagConfigurationMapper;
+    private CustomTemplateConfigMapper $customTagConfigurationMapper;
 
     public function __construct(
         ConfigResolverInterface $configResolver,
@@ -39,7 +53,7 @@ final class CustomTag implements Provider
     }
 
     /**
-     * @return array RichText Custom Tags config
+     * @phpstan-return array<TConfigOutput> RichText Custom Tags config
      */
     public function getConfiguration(): array
     {

--- a/src/lib/Configuration/UI/Mapper/CustomTag.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag.php
@@ -13,35 +13,47 @@ use RuntimeException;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Traversable;
 
 /**
  * RichText Custom Tag configuration mapper.
  *
  * @internal For internal use by RichText package
+ *
+ * @phpstan-type TConfig array{
+ *     label: string,
+ *     description: string,
+ *     is_inline: bool,
+ *     icon?: string,
+ *     attributes: array<string, TConfigAttribute>
+ * }
+ * @phpstan-type TConfigAttribute array{
+ *     type: string,
+ *     required: bool,
+ *     default_value: mixed,
+ *     choices?: array<string>,
+ * }
+ *
+ * @phpstan-import-type TConfigOutput from \Ibexa\FieldTypeRichText\Configuration\Provider\CustomTag
+ * @phpstan-import-type TConfigAttributeOutput from \Ibexa\FieldTypeRichText\Configuration\Provider\CustomTag
  */
 final class CustomTag implements CustomTemplateConfigMapper
 {
-    /** @var array */
-    private $customTagsConfiguration;
+    /** @phpstan-var array<TConfig> */
+    private array $customTagsConfiguration;
 
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    private $translator;
+    private TranslatorInterface $translator;
 
-    /** @var \Symfony\Component\Translation\TranslatorBagInterface */
-    private $translatorBag;
+    private TranslatorBagInterface $translatorBag;
 
-    /** @var \Symfony\Component\Asset\Packages */
-    private $packages;
+    private Packages $packages;
 
-    /** @var \Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag\AttributeMapper[] */
-    private $customTagAttributeMappers;
+    /** @var iterable<\Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag\AttributeMapper> */
+    private iterable $customTagAttributeMappers;
 
-    /** @var \Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag\AttributeMapper[] */
-    private $supportedTagAttributeMappersCache;
+    /** @var array<\Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag\AttributeMapper> */
+    private array $supportedTagAttributeMappersCache;
 
-    /** @var string */
-    private $translationDomain;
+    private string $translationDomain;
 
     /**
      * CustomTag configuration mapper constructor.
@@ -49,12 +61,9 @@ final class CustomTag implements CustomTemplateConfigMapper
      * Note: type-hinting Translator to have an instance which implements
      * both TranslatorInterface and TranslatorBagInterface.
      *
-     * @param array $customTagsConfiguration
-     * @param \Symfony\Contracts\Translation\TranslatorInterface $translator
-     * @param \Symfony\Component\Translation\TranslatorBagInterface $translatorBag
-     * @param string $translationDomain
-     * @param \Symfony\Component\Asset\Packages $packages
-     * @param \Traversable $customTagAttributeMappers
+     * @phpstan-param array<TConfig> $customTagsConfiguration
+     *
+     * @param iterable<\Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag\AttributeMapper> $customTagAttributeMappers
      */
     public function __construct(
         array $customTagsConfiguration,
@@ -62,7 +71,7 @@ final class CustomTag implements CustomTemplateConfigMapper
         TranslatorBagInterface $translatorBag,
         string $translationDomain,
         Packages $packages,
-        Traversable $customTagAttributeMappers
+        iterable $customTagAttributeMappers
     ) {
         $this->customTagsConfiguration = $customTagsConfiguration;
         $this->translator = $translator;
@@ -76,9 +85,9 @@ final class CustomTag implements CustomTemplateConfigMapper
     /**
      * Map Configuration for the given list of enabled Custom Tags.
      *
-     * @param array $enabledCustomTags
+     * @phpstan-param array<string> $enabledCustomTags
      *
-     * @return array Mapped configuration
+     * @phpstan-return array<TConfigOutput> Mapped configuration
      */
     public function mapConfig(array $enabledCustomTags): array
     {
@@ -123,12 +132,6 @@ final class CustomTag implements CustomTemplateConfigMapper
 
     /**
      * Get first available Custom Tag Attribute Type mapper.
-     *
-     * @param string $tagName
-     * @param string $attributeName
-     * @param string $attributeType
-     *
-     * @return \Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag\AttributeMapper
      */
     private function getAttributeTypeMapper(
         string $tagName,
@@ -154,9 +157,9 @@ final class CustomTag implements CustomTemplateConfigMapper
     /**
      * Process Custom Tags config and translate labels for UI.
      *
-     * @param array $config
+     * @param array<string, TConfigOutput> $config
      *
-     * @return array processed Custom Tags config with translated labels
+     * @return array<string, TConfigOutput> processed Custom Tags config with translated labels
      */
     private function translateLabels(array $config): array
     {

--- a/src/lib/Configuration/UI/Mapper/CustomTag/AttributeMapper.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag/AttributeMapper.php
@@ -12,26 +12,23 @@ namespace Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag;
  * Map RichText Custom Tag attribute of supported type to proper UI config.
  *
  * @internal For internal use by RichText package
+ *
+ * @phpstan-import-type TConfigAttribute from \Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag
+ * @phpstan-import-type TConfigAttributeOutput from \Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTag
  */
 interface AttributeMapper
 {
     /**
      * Check if mapper supports given Custom Tag attribute type.
-     *
-     * @param string $attributeType
-     *
-     * @return bool
      */
     public function supports(string $attributeType): bool;
 
     /**
      * Map Configuration for the given Custom Tag attribute type.
      *
-     * @param string $tagName
-     * @param string $attributeName
-     * @param array $customTagAttributeProperties
+     * @phpstan-param TConfigAttribute $customTagAttributeProperties
      *
-     * @return array Mapped attribute configuration
+     * @phpstan-return TConfigAttributeOutput Mapped attribute configuration
      */
     public function mapConfig(
         string $tagName,

--- a/src/lib/Configuration/UI/Mapper/CustomTag/ChoiceAttributeMapper.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag/ChoiceAttributeMapper.php
@@ -30,7 +30,7 @@ final class ChoiceAttributeMapper extends CommonAttributeMapper implements Attri
     ): array {
         $parentConfig = parent::mapConfig($tagName, $attributeName, $customTagAttributeProperties);
 
-        $parentConfig['choices'] = $customTagAttributeProperties['choices'];
+        $parentConfig['choices'] = $customTagAttributeProperties['choices'] ?? [];
         $parentConfig['choicesLabel'] = [];
 
         foreach ($parentConfig['choices'] as $choice) {

--- a/tests/lib/Configuration/Provider/ConfigurableProviderTest.php
+++ b/tests/lib/Configuration/Provider/ConfigurableProviderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\FieldTypeRichText\Configuration\Provider;
+
+use Ibexa\Contracts\FieldTypeRichText\Configuration\Provider;
+use Ibexa\Contracts\FieldTypeRichText\Configuration\ProviderConfiguratorInterface;
+use Ibexa\FieldTypeRichText\Configuration\Provider\ConfigurableProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigurableProviderTest extends TestCase
+{
+    public function testSharesNameWithDecoratedProvider(): void
+    {
+        $inner = $this->createMock(Provider::class);
+        $inner
+            ->expects(self::once())
+            ->method('getName')
+            ->willReturn('__inner_name__');
+
+        $provider = new ConfigurableProvider(
+            $inner,
+            [],
+        );
+
+        self::assertSame('__inner_name__', $provider->getName());
+    }
+
+    public function testConfigurationRemainsSameWithoutCustomConfigurators(): void
+    {
+        $inner = $this->createMock(Provider::class);
+        $inner
+            ->expects(self::once())
+            ->method('getConfiguration')
+            ->willReturn([
+                'foo' => 'bar',
+            ]);
+
+        $provider = new ConfigurableProvider(
+            $inner,
+            [],
+        );
+
+        self::assertSame(['foo' => 'bar'], $provider->getConfiguration());
+    }
+
+    public function testConfigurationReplacedWithCustomConfigurators(): void
+    {
+        $inner = $this->createMock(Provider::class);
+        $inner
+            ->expects(self::once())
+            ->method('getConfiguration')
+            ->willReturn([
+                'foo' => 'bar',
+            ]);
+
+        $configurator = $this->createMock(ProviderConfiguratorInterface::class);
+        $configurator
+            ->expects(self::once())
+            ->method('getConfiguration')
+            ->with(self::identicalTo(['foo' => 'bar']))
+            ->willReturn(['bar' => 'foo']);
+
+        $provider = new ConfigurableProvider(
+            $inner,
+            [$configurator],
+        );
+
+        self::assertSame(['bar' => 'foo'], $provider->getConfiguration());
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-8434 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

This PR introduces `Ibexa\FieldTypeRichText\Configuration\Provider\ConfigurableProvider`, which decorates all available `Ibexa\Contracts\FieldTypeRichText\Configuration\Provider`s.

It's purpose is to allow modification of configuration (as a whole, not single items) before it is passed to frontend.

Alongside it, a `Ibexa\Contracts\FieldTypeRichText\Configuration\ProviderConfiguratorInterface` is introduced to allow injecting small services into the `ConfigurableProvider` that all take turns processing the configuration.

Four new tags are introduced as extension points for use:
 * `ibexa.field_type.richtext.configuration.custom_style.configurator`
 * `ibexa.field_type.richtext.configuration.custom_tag.configurator`
 * `ibexa.field_type.richtext.configuration.alloy_editor.configurator`
 * `ibexa.field_type.richtext.configuration.ck_editor.configurator`

#### For QA:
Testing should be done against a separate PR from Ibexa Engage that requires this feature.

#### Documentation:
As mentioned, four new tags are introduced. Use Ibexa Engage PR (cross linked) for an example on how this can be utilized.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
