### PR TITLE
IBX-8502: Added unsupported locale fallback

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
+++ b/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
@@ -126,10 +126,10 @@ const VIEWPORT_TOP_OFFSET_DISTRACTION_FREE_MODE = 0;
             const section = wrapper.childNodes[0];
             const { toolbar, extraPlugins = [], extraConfig = {} } = window.ibexa.richText.CKEditor;
             let locale;
-            try{
-                locale  = new Intl.Locale(doc.querySelector('meta[name="LanguageCode"]').content);
-            }catch (e){
-                locale  = new Intl.Locale('eng-GB');
+            try {
+                locale = new Intl.Locale(doc.querySelector('meta[name="LanguageCode"]').content);
+            } catch (e) {
+                locale = new Intl.Locale('eng-GB');
             }
             const blockCustomStyles = Object.entries(ibexa.richText.customStyles)
                 .filter(([, customStyleConfig]) => !customStyleConfig.inline)

--- a/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
+++ b/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
@@ -125,7 +125,12 @@ const VIEWPORT_TOP_OFFSET_DISTRACTION_FREE_MODE = 0;
             const wrapper = this.getHTMLDocumentFragment(container.closest('.ibexa-data-source').querySelector('textarea').value);
             const section = wrapper.childNodes[0];
             const { toolbar, extraPlugins = [], extraConfig = {} } = window.ibexa.richText.CKEditor;
-            const locale = new Intl.Locale(doc.querySelector('meta[name="LanguageCode"]').content);
+            let locale;
+            try{
+                locale  = new Intl.Locale(doc.querySelector('meta[name="LanguageCode"]').content);
+            }catch (e){
+                locale  = new Intl.Locale('eng-GB');
+            }
             const blockCustomStyles = Object.entries(ibexa.richText.customStyles)
                 .filter(([, customStyleConfig]) => !customStyleConfig.inline)
                 .map(([customStyleName, customStyleConfig]) => {

--- a/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
+++ b/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
@@ -129,6 +129,9 @@ const VIEWPORT_TOP_OFFSET_DISTRACTION_FREE_MODE = 0;
             try {
                 locale = new Intl.Locale(doc.querySelector('meta[name="LanguageCode"]').content);
             } catch (e) {
+                console.warn(
+                    `Unsupported LanguageCode '${doc.querySelector('meta[name="LanguageCode"]').content}' - using fallback 'eng-GB'.`,
+                );
                 locale = new Intl.Locale('eng-GB');
             }
             const blockCustomStyles = Object.entries(ibexa.richText.customStyles)


### PR DESCRIPTION
| :ticket: Issue | IBX-8502 |
|----------------|-----------|

Issue seems to come from the fact that `Intl` does not support 3 letter region subtags:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl

```
A locale identifier is a string that consists of:
# A language subtag with 2–3 or 5–8 letters
# A script subtag with 4 letters Optional
# A region subtag with either 2 letters or 3 digits Optional (!)
# One or more variant subtags (all of which must be unique), each with either 5–8 alphanumerals or a digit followed by 3 alphanumerals Optional
# One or more BCP 47 extension sequences Optional
# A private-use extension sequence Optional
```
PR adds a fallback to `eng-GB` for locales not supported by `Intl`.