### PR TITLE
IBX-8534: Dropped deprecated context and getIndexData from Storage

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -416,11 +416,6 @@ parameters:
 			path: src/lib/FieldType/RichText/RichTextStorage.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\RichTextStorage\\:\\:deleteFieldData\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
 			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\RichTextStorage\\:\\:deleteFieldData\\(\\) has parameter \\$fieldIds with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/FieldType/RichText/RichTextStorage.php
@@ -432,26 +427,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\RichTextStorage\\:\\:getFieldData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\RichTextStorage\\:\\:getFieldData\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\RichTextStorage\\:\\:getIndexData\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\RichTextStorage\\:\\:getIndexData\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Search\\\\Field\\> but return statement is missing\\.$#"
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\RichTextStorage\\:\\:storeFieldData\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/FieldType/RichText/RichTextStorage.php
 
@@ -1704,11 +1679,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Tests\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\Gateway\\\\DoctrineStorageTest\\:\\:\\$storageGateway \\(Ibexa\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\RichTextStorage\\\\Gateway\\\\DoctrineStorage\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: tests/lib/FieldType/RichText/Gateway/DoctrineStorageTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\RichTextStorageTest\\:\\:getContext\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\FieldTypeRichText\\\\FieldType\\\\RichText\\\\RichTextStorageTest\\:\\:groupLinksData\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/src/lib/FieldType/RichText/RichTextStorage.php
+++ b/src/lib/FieldType/RichText/RichTextStorage.php
@@ -42,7 +42,7 @@ class RichTextStorage extends GatewayBasedStorage
     /**
      * @see \Ibexa\Contracts\Core\FieldType\FieldStorage
      */
-    public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
+    public function storeFieldData(VersionInfo $versionInfo, Field $field)
     {
         $document = new DOMDocument();
         $document->loadXML($field->value->data);
@@ -128,12 +128,8 @@ class RichTextStorage extends GatewayBasedStorage
 
     /**
      * Modifies $field if needed, using external data (like for Urls).
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Content\VersionInfo $versionInfo
-     * @param \Ibexa\Contracts\Core\Persistence\Content\Field $field
-     * @param array $context
      */
-    public function getFieldData(VersionInfo $versionInfo, Field $field, array $context)
+    public function getFieldData(VersionInfo $versionInfo, Field $field)
     {
         $document = new DOMDocument();
         $document->loadXML($field->value->data);
@@ -186,7 +182,7 @@ class RichTextStorage extends GatewayBasedStorage
         $field->value->data = $document->saveXML();
     }
 
-    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds, array $context)
+    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds)
     {
         foreach ($fieldIds as $fieldId) {
             $this->gateway->unlinkUrl($fieldId, $versionInfo->versionNo);
@@ -201,9 +197,5 @@ class RichTextStorage extends GatewayBasedStorage
     public function hasFieldData()
     {
         return true;
-    }
-
-    public function getIndexData(VersionInfo $versionInfo, Field $field, array $context)
-    {
     }
 }

--- a/tests/lib/FieldType/RichText/RichTextStorageTest.php
+++ b/tests/lib/FieldType/RichText/RichTextStorageTest.php
@@ -95,8 +95,7 @@ class RichTextStorageTest extends TestCase
         $storage = $this->getPartlyMockedStorage($gateway);
         $storage->getFieldData(
             $versionInfo,
-            $field,
-            $this->getContext()
+            $field
         );
 
         self::assertEquals(
@@ -238,8 +237,7 @@ class RichTextStorageTest extends TestCase
         $storage = $this->getPartlyMockedStorage($gateway);
         $result = $storage->storeFieldData(
             $versionInfo,
-            $field,
-            $this->getContext()
+            $field
         );
 
         self::assertEquals(
@@ -345,8 +343,7 @@ class RichTextStorageTest extends TestCase
         $storage = $this->getPartlyMockedStorage($gateway);
         $storage->storeFieldData(
             $versionInfo,
-            $field,
-            $this->getContext()
+            $field
         );
     }
 
@@ -366,8 +363,7 @@ class RichTextStorageTest extends TestCase
 
         $storage->deleteFieldData(
             $versionInfo,
-            $fieldIds,
-            $this->getContext()
+            $fieldIds
         );
     }
 
@@ -387,14 +383,6 @@ class RichTextStorageTest extends TestCase
             )
             ->setMethods(null)
             ->getMock();
-    }
-
-    /**
-     * @return array
-     */
-    protected function getContext()
-    {
-        return ['context'];
     }
 
     /**


### PR DESCRIPTION
| :ticket: Issue | IBX-8534 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/435

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
