### PR TITLE
IBX-9243: linebreaks in Inline custom tags markup (eztemplateinline) breakes the editor

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/inline-custom-tag/inline-custom-tag-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/inline-custom-tag/inline-custom-tag-editing.js
@@ -1,6 +1,7 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import { toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
+import Element from '@ckeditor/ckeditor5-engine/src/view/element';
 
 import IbexaInlineCustomTagCommand from './inline-custom-tag-command';
 
@@ -92,6 +93,10 @@ class IbexaInlineCustomTagEditing extends Plugin {
                 const values = {};
 
                 for (const configValue of configValuesIterator) {
+                    if (configValue instanceof Element === false) {
+                        continue;
+                    }
+
                     const value = configValue.getChild(0)?.data ?? null;
 
                     values[configValue.getAttribute('data-ezvalue-key')] = value;


### PR DESCRIPTION
| :ticket: Issue | [IBX-9243](https://issues.ibexa.co/browse/IBX-9243) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
