### PR TITLE
IBX-9296: Custom CSS classes not working for "embedimage"

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/custom-attributes/helpers/config-helper.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-attributes/helpers/config-helper.js
@@ -52,6 +52,14 @@ const getCustomClassesElementConfig = (elementName) => {
 
     return config[configName];
 };
+const addPredefinedClassToConfig = (elementName, className) => {
+    const configName = findConfigName(elementName);
+    const config = window.ibexa.richText.alloyEditor.classes[configName];
+
+    if (config) {
+        config.predefinedClass = className;
+    }
+};
 
 export {
     getCustomAttributesConfig,
@@ -59,4 +67,5 @@ export {
     getCustomAttributesElementConfig,
     getCustomClassesElementConfig,
     findConfigName,
+    addPredefinedClassToConfig,
 };

--- a/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
@@ -5,6 +5,9 @@ import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import IbexaEmbedImageCommand from './embed-image-command';
 
 import { findContent } from '../../services/content-service';
+import { addPredefinedClassToConfig } from '../../custom-attributes/helpers/config-helper';
+
+const CONTAINER_CLASS = 'ibexa-embed-type-image';
 
 class IbexaEmbedImageEditing extends Plugin {
     static get requires() {
@@ -17,6 +20,8 @@ class IbexaEmbedImageEditing extends Plugin {
         this.loadImagePreview = this.loadImagePreview.bind(this);
         this.loadImageVariation = this.loadImageVariation.bind(this);
         this.getSetting = this.getSetting.bind(this);
+
+        addPredefinedClassToConfig('embedImage', CONTAINER_CLASS);
     }
 
     loadImagePreview(modelElement) {
@@ -89,7 +94,7 @@ class IbexaEmbedImageEditing extends Plugin {
                     const container = downcastWriter.createContainerElement('div', {
                         'data-ezelement': 'ezembed',
                         'data-ezview': 'embed',
-                        class: 'ibexa-embed-type-image',
+                        class: CONTAINER_CLASS,
                     });
 
                     this.loadImagePreview(modelElement);
@@ -136,7 +141,7 @@ class IbexaEmbedImageEditing extends Plugin {
                     'data-href': `ezcontent://${modelElement.getAttribute('contentId')}`,
                     'data-ezelement': 'ezembed',
                     'data-ezview': 'embed',
-                    class: 'ibexa-embed-type-image',
+                    class: CONTAINER_CLASS,
                 });
                 const config = downcastWriter.createUIElement('span', { 'data-ezelement': 'ezconfig' }, function (domDocument) {
                     const domElement = this.toDomElement(domDocument);
@@ -177,7 +182,7 @@ class IbexaEmbedImageEditing extends Plugin {
                 attributes: {
                     'data-ezelement': 'ezembed',
                 },
-                classes: 'ibexa-embed-type-image',
+                classes: CONTAINER_CLASS,
             },
             model: (viewElement, { writer: upcastWriter }) => {
                 const href = viewElement.getAttribute('data-href');


### PR DESCRIPTION
| :ticket: Issue | [IBX-9296](https://issues.ibexa.co/browse/IBX-9296) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Custom class was there under `custom-classes` attribute, but it was in form of `ibexa-embed-type-image {custom_class}` so `cleanClasses` method was removing this whole attribute (as `ibexa-embed-type-image` wasn't in custom classes options config and all custom-classes had to be matched)

I've added to config info about this component class and before any checks I remove it from attribute.
Also, I have to remove it later manually from model attributes, as otherwise `ibexa-embed-type-image` is duplicated - probably comes from container declaration and from custom-classes, co one of these origins had to be cleared.
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
