### PR TITLE
IBX-8962: Unable to use certain special characters in richtext links

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/link/link-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/link/link-ui.js
@@ -59,7 +59,7 @@ class IbexaLinkUI extends Plugin {
 
             this.isNew = false;
 
-            this.editor.execute('insertIbexaLink', { href: url, title, target, ibexaLinkClasses, ibexaLinkAttributes });
+            this.editor.execute('insertIbexaLink', { href: encodeURI(url), title, target, ibexaLinkClasses, ibexaLinkAttributes });
             this.hideForm();
         });
 

--- a/src/bundle/Resources/public/js/CKEditor/link/ui/link-form-view.js
+++ b/src/bundle/Resources/public/js/CKEditor/link/ui/link-form-view.js
@@ -122,7 +122,7 @@ class IbexaLinkFormView extends View {
     }
 
     setValues({ url, title, target, ibexaLinkClasses, ibexaLinkAttributes = {} }) {
-        this.setStringValue(this.urlInputView, url);
+        this.setStringValue(this.urlInputView, decodeURI(url));
         this.setStringValue(this.titleView, title);
 
         this.targetSwitcherView.fieldView.element.value = !!target;


### PR DESCRIPTION
| :ticket: Issue | IBX-8962 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
