### PR TITLE
IBX-9392: Richtext editor menu is hidden below "ibexa-edit-header"

### DIFF
--- a/src/bundle/Resources/public/scss/_balloon-form.scss
+++ b/src/bundle/Resources/public/scss/_balloon-form.scss
@@ -145,7 +145,7 @@
     }
 
     .ck-toolbar-container {
-        z-index: calc(var(--ck-z-modal) - 1);
+        z-index: calc(var(--ck-z-modal) + 50);
 
         &.ck-balloon-panel_with-arrow {
             z-index: calc(var(--ck-z-modal) + 1);


### PR DESCRIPTION
| :ticket: Issue | IBX-9392 |
|----------------|-----------|

#### Problem likely introduced in fix for [IBX-6354](https://issues.ibexa.co/browse/IBX-6354): 
- https://github.com/ibexa/fieldtype-richtext/pull/124

#### Description:
Toolbar appears below title/locaton header:
![image-2025-01-17-10-57-06-010](https://github.com/user-attachments/assets/fd6323ec-66dd-4365-88ec-ea443b6f67b7)

After fix:
![image](https://github.com/user-attachments/assets/f6db4474-33a4-4b67-978d-908f273f619e)



Fix does not seem to break IBX-6354:
![image](https://github.com/user-attachments/assets/54f24f6d-feba-4307-aaea-c48622ce7136)




#### For QA:
- See ticket for how to reproduce.. Should do regression test and see that IBX-6354 doesn't break



<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
