### PR TITLE
IBX-9509: Revert deprecation of custom attributes labels extractor

### DIFF
--- a/src/bundle/Resources/config/translation.yaml
+++ b/src/bundle/Resources/config/translation.yaml
@@ -5,7 +5,6 @@ services:
         public: false
 
     Ibexa\FieldTypeRichText\Translation\Extractor\OnlineEditorCustomAttributesExtractor:
-        deprecated: 'Since ibexa/fieldtype-richtext 4.6.7 the "%service_id%" service is deprecated, will be removed in 5.0.0'
         arguments:
             $siteAccessList: '%ibexa.site_access.list%'
         tags:

--- a/src/lib/Translation/Extractor/OnlineEditorCustomAttributesExtractor.php
+++ b/src/lib/Translation/Extractor/OnlineEditorCustomAttributesExtractor.php
@@ -14,9 +14,6 @@ use JMS\TranslationBundle\Model\Message\XliffMessage;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\ExtractorInterface;
 
-/**
- * @deprecated 4.6.7 The "OnlineEditorCustomAttributesExtractor" class is deprecated, will be removed in 5.0.
- */
 final class OnlineEditorCustomAttributesExtractor implements ExtractorInterface
 {
     private const MESSAGE_DOMAIN = 'online_editor';
@@ -55,7 +52,7 @@ final class OnlineEditorCustomAttributesExtractor implements ExtractorInterface
         $catalogue->add($this->createMessage(self::CLASS_LABEL_MESSAGE_ID, 'Class'));
 
         foreach ($this->siteAccessList as $scope) {
-            if (!$this->configResolver->hasParameter(RichText::ATTRIBUTES_SA_SETTINGS_ID)) {
+            if (!$this->configResolver->hasParameter(RichText::ATTRIBUTES_SA_SETTINGS_ID, null, $scope)) {
                 continue;
             }
             $this->extractMessagesForScope($catalogue, $scope);


### PR DESCRIPTION
| :ticket: Issue | [IBX-9509](https://issues.ibexa.co/browse/IBX-9509) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
When doing merge up there will be need for extra work, as this class was removed in 5.0 https://github.com/ibexa/fieldtype-richtext/pull/185
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
