### PR TITLE
IBX-9513: Fixed obsolete `ibexa_content` Controller references

### DIFF
--- a/src/bundle/Resources/views/RichText/embed/content.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/content.html.twig
@@ -19,7 +19,7 @@
     {{
         render(
             controller(
-                "ibexa_content:embedAction",
+                "ibexa_content::embedAction",
                 {
                     "contentId": embedParams.id,
                     "viewType": embedParams.viewType,

--- a/src/bundle/Resources/views/RichText/embed/content_inline.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/content_inline.html.twig
@@ -17,7 +17,7 @@
 {{
     render(
         controller(
-            "ibexa_content:viewAction",
+            "ibexa_content::viewAction",
             {
                 "contentId": embedParams.id,
                 "viewType": embedParams.viewType,

--- a/src/bundle/Resources/views/RichText/embed/location.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/location.html.twig
@@ -18,7 +18,7 @@
     {{
         render(
             controller(
-                "ibexa_content:viewAction",
+                "ibexa_content::viewAction",
                 {
                     "locationId": embedParams.id,
                     "viewType": embedParams.viewType,

--- a/src/bundle/Resources/views/RichText/embed/location_inline.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/location_inline.html.twig
@@ -17,7 +17,7 @@
 {{
     render(
         controller(
-            "ibexa_content:viewAction",
+            "ibexa_content::viewAction",
             {
                 "locationId": embedParams.id,
                 "viewType": embedParams.viewType,


### PR DESCRIPTION
| :ticket: Issue | IBX-9513 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/fieldtype-query/pull/35
- https://github.com/ibexa/core/pull/474
- https://github.com/ibexa/http-cache/pull/56

#### Description:

Fixed obsolete `ibexa_content:` single colon controller references.


#### For QA:

In theory should be visible when trying to embed content inside a RichText field.