### PR TITLE
IBX-8849: Texts "Title" and "Undefined" in Landing page Block rich text link are bad aligned

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/link/link-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/link/link-ui.js
@@ -118,9 +118,9 @@ class IbexaLinkUI extends Plugin {
         const customClassesLinkConfig = customClassesConfig.link;
         const link = this.findLinkElement();
         const values = {
-            url: link ? link.getAttribute('href') : '',
-            title: link ? link.getAttribute('title') : '',
-            target: link ? link.getAttribute('target') : '',
+            url: link?.getAttribute('href') ?? '',
+            title: link?.getAttribute('title') ?? '',
+            target: link?.getAttribute('target') ?? '',
         };
 
         if (customClassesLinkConfig) {


### PR DESCRIPTION
| :ticket: Issue | [IBX-8849](https://issues.ibexa.co/browse/IBX-8849) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Bug occurs when we pass undefined value, therefore this change sets value to null either if link doesn't exist or getAttribute returns undefined
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
