### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,31 @@ jobs:
             - name: Run code style check
               run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+    rector:
+        name: Run rector
+        runs-on: "ubuntu-22.04"
+        strategy:
+            matrix:
+                php:
+                    - '8.3'
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: 'pdo_sqlite, gd'
+                    tools: cs2pr
+
+            -   uses: ramsey/composer-install@v3
+                with:
+                    dependency-versions: highest
+
+            -   name: Run rector
+                run: vendor/bin/rector process --dry-run --ansi
+
     tests:
         name: Tests
         runs-on: ubuntu-22.04

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "ibexa/design-engine": "~5.0.x-dev",
         "ibexa/doctrine-schema": "~5.0.x-dev",
         "ibexa/notifications": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "ibexa/search": "~5.0.x-dev",
         "ibexa/solr": "~5.0.x-dev",
         "ibexa/test-core": "~5.0.x-dev",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -566,11 +566,6 @@ parameters:
 			path: src/lib/Form/Mapper/RichTextFormMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Form\\\\Type\\\\RichTextFieldType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Form/Type/RichTextFieldType.php
-
-		-
 			message: "#^Method Ibexa\\\\FieldTypeRichText\\\\Form\\\\Type\\\\RichTextFieldType\\:\\:getName\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Form/Type/RichTextFieldType.php

--- a/rector.php
+++ b/rector.php
@@ -18,4 +18,5 @@ return RectorConfig::configure()
     ->withSets([
         IbexaSetList::IBEXA_50->value,
         SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
    ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_60,
+   ]);

--- a/rector.php
+++ b/rector.php
@@ -19,4 +19,7 @@ return RectorConfig::configure()
         IbexaSetList::IBEXA_50->value,
         SymfonySetList::SYMFONY_60,
         SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
    ]);

--- a/src/bundle/Command/MigrateRichTextNamespacesCommand.php
+++ b/src/bundle/Command/MigrateRichTextNamespacesCommand.php
@@ -10,15 +10,15 @@ namespace Ibexa\Bundle\FieldTypeRichText\Command;
 
 use Ibexa\FieldTypeRichText\Persistence\MigrateRichTextNamespacesHandlerInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'ibexa:migrate:richtext-namespaces')]
 final class MigrateRichTextNamespacesCommand extends Command
 {
-    protected static $defaultName = 'ibexa:migrate:richtext-namespaces';
-
     private MigrateRichTextNamespacesHandlerInterface $handler;
 
     private TagAwareAdapterInterface $cache;

--- a/src/bundle/Templating/Twig/Extension/RichTextConverterExtension.php
+++ b/src/bundle/Templating/Twig/Extension/RichTextConverterExtension.php
@@ -34,12 +34,12 @@ class RichTextConverterExtension extends AbstractExtension
         return [
             new TwigFilter(
                 'ibexa_richtext_to_html5',
-                [$this, 'richTextToHtml5'],
+                $this->richTextToHtml5(...),
                 ['is_safe' => ['html']]
             ),
             new TwigFilter(
                 'ibexa_richtext_to_html5_edit',
-                [$this, 'richTextToHtml5Edit'],
+                $this->richTextToHtml5Edit(...),
                 ['is_safe' => ['html']]
             ),
         ];

--- a/src/bundle/Templating/Twig/Extension/YoutubeIdExtractorExtension.php
+++ b/src/bundle/Templating/Twig/Extension/YoutubeIdExtractorExtension.php
@@ -24,7 +24,7 @@ final class YoutubeIdExtractorExtension extends AbstractExtension
         return [
             new TwigFunction(
                 'ibexa_richtext_youtube_extract_id',
-                [$this, 'extractId']
+                $this->extractId(...)
             ),
         ];
     }

--- a/src/lib/Form/Type/RichTextFieldType.php
+++ b/src/lib/Form/Type/RichTextFieldType.php
@@ -47,7 +47,7 @@ class RichTextFieldType extends AbstractType
         return TextareaType::class;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addModelTransformer(new RichTextValueTransformer(
             $this->fieldTypeService->getFieldType('ezrichtext'),


### PR DESCRIPTION
| :ticket: Issue | IBX-9584 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Enabled and executed automatic refactoring rules defined for Symfony 6.x.

* [Form] Added missing return type declarations
* [CLI] Replaced deprecated Command::{$defaultName, $defaultDescription} with the AsCommand attribute
* [PHP] Updated method reference syntax

Additionally added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+. 

#### For QA:

Sanities.

#### Documentation:

N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
