### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,18 +37,6 @@ parameters:
 			path: src/bundle/DependencyInjection/Configuration.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\FieldTypeRichText\\DependencyInjection\\Configuration\\Parser\\FieldType\\RichText\:\:addFieldTypeSemanticConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\FieldTypeRichText\\DependencyInjection\\Configuration\\Parser\\FieldType\\RichText\:\:mapConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\FieldTypeRichText\\DependencyInjection\\Configuration\\Parser\\FieldType\\RichText\:\:mapConfig\(\) has parameter \$scopeSettings with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -111,12 +99,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Bundle\\FieldTypeRichText\\DependencyInjection\\IbexaFieldTypeRichTextExtension\:\:getToolbarsBySiteAccess\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/bundle/DependencyInjection/IbexaFieldTypeRichTextExtension.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\FieldTypeRichText\\DependencyInjection\\IbexaFieldTypeRichTextExtension\:\:load\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaFieldTypeRichTextExtension.php
 
@@ -189,12 +171,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Bundle\\FieldTypeRichText\\IbexaFieldTypeRichTextBundle\:\:getCoreExtension\(\) should return Ibexa\\Bundle\\Core\\DependencyInjection\\IbexaCoreExtension but returns Symfony\\Component\\DependencyInjection\\Extension\\ExtensionInterface\.$#'
 			identifier: return.type
-			count: 1
-			path: src/bundle/IbexaFieldTypeRichTextBundle.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\FieldTypeRichText\\IbexaFieldTypeRichTextBundle\:\:registerConfigParser\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/bundle/IbexaFieldTypeRichTextBundle.php
 
@@ -487,69 +463,9 @@ parameters:
 			path: src/lib/FieldType/RichText/RichTextStorage.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorage\:\:deleteFieldData\(\) should return bool but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorage\:\:getFieldData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: '#^Offset 1 might not exist on array\{0\?\: string, 1\?\: ''''\|''ezremote\://'', 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: '#^Offset 1 might not exist on array\{0\?\: string, 1\?\: string, 2\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: '#^Offset 2 might not exist on array\{0\?\: string, 1\: ''ezremote\://'', 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: '#^Offset 2 might not exist on array\{0\?\: string, 1\?\: ''''\|''ezremote\://'', 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 2
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: '#^Offset 2 might not exist on array\{0\?\: string, 1\?\: string, 2\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: '#^Offset 3 might not exist on array\{0\?\: string, 1\?\: ''''\|''ezremote\://'', 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
 			message: '#^Parameter \#1 \$source of method DOMDocument\:\:loadXML\(\) expects string, array\|bool\|float\|int\|string\|null given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: '#^Property Ibexa\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorage\:\:\$logger \(Psr\\Log\\LoggerInterface\) does not accept Psr\\Log\\LoggerInterface\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage.php
-
-		-
-			message: '#^Property Ibexa\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorage\:\:\$logger \(Psr\\Log\\LoggerInterface\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
-			count: 1
 			path: src/lib/FieldType/RichText/RichTextStorage.php
 
 		-
@@ -573,18 +489,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorage\\Gateway\:\:getUrlIdMap\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage/Gateway.php
-
-		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorage\\Gateway\:\:linkUrl\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/FieldType/RichText/RichTextStorage/Gateway.php
-
-		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorage\\Gateway\:\:unlinkUrl\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/lib/FieldType/RichText/RichTextStorage/Gateway.php
 
@@ -667,18 +571,6 @@ parameters:
 			path: src/lib/Form/DataTransformer/RichTextValueTransformer.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\Form\\Mapper\\RichTextFormMapper\:\:configureOptions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Form/Mapper/RichTextFormMapper.php
-
-		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\Form\\Mapper\\RichTextFormMapper\:\:mapFieldValueForm\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Form/Mapper/RichTextFormMapper.php
-
-		-
 			message: '#^Method Ibexa\\FieldTypeRichText\\Form\\Mapper\\RichTextFormMapper\:\:mapFieldValueForm\(\) has parameter \$fieldForm with generic interface Symfony\\Component\\Form\\FormInterface but does not specify its types\: TData$#'
 			identifier: missingType.generics
 			count: 1
@@ -691,40 +583,10 @@ parameters:
 			path: src/lib/Form/Type/RichTextFieldType.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\Form\\Type\\RichTextFieldType\:\:getName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Form/Type/RichTextFieldType.php
-
-		-
 			message: '#^Class Ibexa\\FieldTypeRichText\\Form\\Type\\RichTextType extends generic class Symfony\\Component\\Form\\AbstractType but does not specify its types\: TData$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/lib/Form/Type/RichTextType.php
-
-		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\Persistence\\Legacy\\RichTextFieldValueConverter\:\:toFieldDefinition\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Persistence/Legacy/RichTextFieldValueConverter.php
-
-		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\Persistence\\Legacy\\RichTextFieldValueConverter\:\:toFieldValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Persistence/Legacy/RichTextFieldValueConverter.php
-
-		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\Persistence\\Legacy\\RichTextFieldValueConverter\:\:toStorageFieldDefinition\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Persistence/Legacy/RichTextFieldValueConverter.php
-
-		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\Persistence\\Legacy\\RichTextFieldValueConverter\:\:toStorageValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Persistence/Legacy/RichTextFieldValueConverter.php
 
 		-
 			message: '#^Property Ibexa\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue\:\:\$dataText \(string\) does not accept array\|bool\|float\|int\|string\|null\.$#'
@@ -745,32 +607,8 @@ parameters:
 			path: src/lib/RichText/Converter/Link.php
 
 		-
-			message: '#^Offset 1 might not exist on array\{0\?\: string, 1\?\: string, 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/RichText/Converter/Link.php
-
-		-
-			message: '#^Offset 2 might not exist on array\{0\?\: string, 1\?\: string, 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/RichText/Converter/Link.php
-
-		-
-			message: '#^Offset 3 might not exist on array\{0\?\: string, 1\?\: string, 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/RichText/Converter/Link.php
-
-		-
 			message: '#^Parameter \#1 \$locationId of method Ibexa\\Contracts\\Core\\Repository\\LocationService\:\:loadLocation\(\) expects int, int\|null given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/lib/RichText/Converter/Link.php
-
-		-
-			message: '#^Property Ibexa\\FieldTypeRichText\\RichText\\Converter\\Link\:\:\$logger \(Psr\\Log\\LoggerInterface\) does not accept Psr\\Log\\LoggerInterface\|null\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: src/lib/RichText/Converter/Link.php
 
@@ -901,12 +739,6 @@ parameters:
 			path: src/lib/RichText/Converter/Render/Embed.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\RichText\\Converter\\Render\\Embed\:\:extractLinkParameters\(\) should return array but returns null\.$#'
-			identifier: return.type
-			count: 2
-			path: src/lib/RichText/Converter/Render/Embed.php
-
-		-
 			message: '#^Method Ibexa\\FieldTypeRichText\\RichText\\Converter\\Render\\Embed\:\:extractParameters\(\) has parameter \$tagName with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -933,24 +765,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\FieldTypeRichText\\RichText\\Converter\\Render\\Embed\:\:processTag\(\) has parameter \$tagName with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: src/lib/RichText/Converter/Render/Embed.php
-
-		-
-			message: '#^Offset 1 might not exist on array\{0\?\: string, 1\?\: ''ezcontent''\|''ezlocation'', 2\?\: numeric\-string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/RichText/Converter/Render/Embed.php
-
-		-
-			message: '#^Offset 2 might not exist on array\{0\?\: string, 1\: ''ezcontent'', 2\?\: numeric\-string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/RichText/Converter/Render/Embed.php
-
-		-
-			message: '#^Offset 2 might not exist on array\{0\?\: string, 1\: ''ezlocation'', 2\?\: numeric\-string\}\.$#'
-			identifier: offsetAccess.notFound
 			count: 1
 			path: src/lib/RichText/Converter/Render/Embed.php
 
@@ -1063,12 +877,6 @@ parameters:
 			path: src/lib/RichText/ConverterDispatcher.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\RichText\\ConverterDispatcher\:\:addConverter\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/RichText/ConverterDispatcher.php
-
-		-
 			message: '#^Property Ibexa\\FieldTypeRichText\\RichText\\ConverterDispatcher\:\:\$mapping \(array\<Ibexa\\Contracts\\FieldTypeRichText\\RichText\\Converter\>\) does not accept array\<Ibexa\\Contracts\\FieldTypeRichText\\RichText\\Converter\|null\>\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -1117,12 +925,6 @@ parameters:
 			path: src/lib/RichText/Normalizer/DocumentTypeDefinition.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\RichText\\Normalizer\\DocumentTypeDefinition\:\:normalize\(\) should return string but returns string\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/RichText/Normalizer/DocumentTypeDefinition.php
-
-		-
 			message: '#^Argument of an invalid type DOMNodeList\<DOMNode\>\|false supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1
@@ -1145,30 +947,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/RichText/RelationProcessor.php
-
-		-
-			message: '#^Offset 1 might not exist on array\{0\?\: string, 1\?\: non\-empty\-string, 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/RichText/RelationProcessor.php
-
-		-
-			message: '#^Offset 2 might not exist on array\{0\?\: string, 1\?\: non\-empty\-string, 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/RichText/RelationProcessor.php
-
-		-
-			message: '#^Cannot call method error\(\) on Psr\\Log\\LoggerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 13
-			path: src/lib/RichText/Renderer.php
-
-		-
-			message: '#^Cannot call method warning\(\) on Psr\\Log\\LoggerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 6
-			path: src/lib/RichText/Renderer.php
 
 		-
 			message: '#^Method Ibexa\\FieldTypeRichText\\RichText\\Renderer\:\:__construct\(\) has parameter \$customStylesConfiguration with no value type specified in iterable type array\.$#'
@@ -1227,12 +1005,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\FieldTypeRichText\\RichText\\Renderer\:\:renderTemplate\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/RichText/Renderer.php
-
-		-
-			message: '#^Parameter \#1 \$locationId of method Ibexa\\Contracts\\Core\\Repository\\LocationService\:\:loadLocation\(\) expects int, int\|string given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/lib/RichText/Renderer.php
 
@@ -1303,30 +1075,6 @@ parameters:
 			path: src/lib/RichText/Validator/InternalLinkValidator.php
 
 		-
-			message: '#^Offset 1 might not exist on array\{0\?\: string, 1\?\: non\-empty\-string, 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/RichText/Validator/InternalLinkValidator.php
-
-		-
-			message: '#^Offset 2 might not exist on array\{0\?\: string, 1\?\: non\-empty\-string, 2\?\: string, 3\?\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/lib/RichText/Validator/InternalLinkValidator.php
-
-		-
-			message: '#^PHPDoc tag @var has invalid value \(\\Ibexa\\Contracts\\Core\\Persistence\\Content\\Location\\Handler;\)\: Unexpected token ";", expected TOKEN_HORIZONTAL_WS at offset 74 on line 2$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/lib/RichText/Validator/InternalLinkValidator.php
-
-		-
-			message: '#^Property Ibexa\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidator\:\:\$locationHandler has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/lib/RichText/Validator/InternalLinkValidator.php
-
-		-
 			message: '#^Argument of an invalid type DOMNodeList\<DOMNode\>\|false supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1
@@ -1363,12 +1111,6 @@ parameters:
 			path: src/lib/RichText/Validator/ValidatorAggregate.php
 
 		-
-			message: '#^Property Ibexa\\FieldTypeRichText\\RichText\\Validator\\ValidatorAggregate\:\:\$validators \(array\<Ibexa\\Contracts\\FieldTypeRichText\\RichText\\ValidatorInterface\>\) does not accept iterable\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/lib/RichText/Validator/ValidatorAggregate.php
-
-		-
 			message: '#^Call to method validate\(\) on an unknown class Ibexa\\FieldTypeRichText\\eZ\\RichText\\Validator\.$#'
 			identifier: class.notFound
 			count: 1
@@ -1378,12 +1120,6 @@ parameters:
 			message: '#^Cannot call method lookupNamespaceURI\(\) on DOMElement\|null\.$#'
 			identifier: method.nonObject
 			count: 2
-			path: src/lib/RichText/Validator/ValidatorDispatcher.php
-
-		-
-			message: '#^Method Ibexa\\FieldTypeRichText\\RichText\\Validator\\ValidatorDispatcher\:\:addValidator\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
 			path: src/lib/RichText/Validator/ValidatorDispatcher.php
 
 		-
@@ -1453,12 +1189,6 @@ parameters:
 			path: src/lib/Validator/Constraints/RichTextValidator.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\FieldTypeRichText\\DependencyInjection\\Compiler\\RichTextHtml5ConverterPassTest\:\:testCollectProviders\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\FieldTypeRichText\\DependencyInjection\\Configuration\\ConfigurationTest\:\:providerForTestProcessingConfiguration\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1513,32 +1243,8 @@ parameters:
 			path: tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\FieldTypeRichText\\DependencyInjection\\Configuration\\Parser\\FieldType\\RichTextTest\:\:richTextSettingsProvider\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\FieldTypeRichText\\DependencyInjection\\Configuration\\Parser\\FieldType\\RichTextTest\:\:testDefaultContentSettings\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\FieldTypeRichText\\DependencyInjection\\Configuration\\Parser\\FieldType\\RichTextTest\:\:testOnlineEditorInvalidSettingsThrowException\(\) has parameter \$config with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\FieldTypeRichText\\DependencyInjection\\Configuration\\Parser\\FieldType\\RichTextTest\:\:testRichTextCustomTagsInvalidSettings\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\FieldTypeRichText\\DependencyInjection\\Configuration\\Parser\\FieldType\\RichTextTest\:\:testRichTextSettings\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
 
@@ -1627,36 +1333,6 @@ parameters:
 			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:__construct\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:assertCopiedFieldDataLoadedCorrectly\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:assertFieldDataLoadedCorrect\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:assertUpdatedFieldDataLoadedCorrect\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:assertUpdatedFieldDataLoadedCorrect\(\) should return array but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:checkSearchEngineSupport\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -1677,18 +1353,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:getSettingsSchema\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:getValidUpdateFieldData\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:getValidUpdateFieldData\(\) should return array but returns Ibexa\\FieldTypeRichText\\FieldType\\RichText\\Value\.$#'
-			identifier: return.type
 			count: 1
 			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
 
@@ -1729,12 +1393,6 @@ parameters:
 			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:providerForTestConvertRemoteObjectIdToObjectId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:providerForTestCreateContentWithInvalidCustomTag\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1771,24 +1429,6 @@ parameters:
 			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:testCreateContentWithInvalidCustomTag\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:testCreateContentWithValidCustomTag\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:testFromHash\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:testFromHash\(\) has parameter \$expectedValue with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -1797,18 +1437,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:testFromHash\(\) has parameter \$hash with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:testInternalLinkValidatorIgnoresMissingRelationOnNotUpdatedField\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\FieldTypeRichText\\Repository\\RichTextFieldTypeIntegrationTest\:\:testInternalLinkValidatorReturnsErrorOnMissingRelationInUpdatedField\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
 
@@ -1843,38 +1471,8 @@ parameters:
 			path: tests/integration/Repository/SetupFactory/SolrLegacySetupFactory.php
 
 		-
-			message: '#^Method Ibexa\\Contracts\\FieldTypeRichText\\Configuration\\Provider@anonymous/tests/lib/Configuration/AggregateProviderTest\.php\:31\:\:__construct\(\) has parameter \$configuration with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Configuration/AggregateProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\FieldTypeRichText\\Configuration\\Provider@anonymous/tests/lib/Configuration/AggregateProviderTest\.php\:31\:\:getConfiguration\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Configuration/AggregateProviderTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Configuration\\AggregateProviderTest\:\:getConfiguration\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Configuration/AggregateProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Configuration\\AggregateProviderTest\:\:testGetConfiguration\(\) has parameter \$configuration with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Configuration/AggregateProviderTest.php
-
-		-
-			message: '#^Property Ibexa\\Contracts\\FieldTypeRichText\\Configuration\\Provider@anonymous/tests/lib/Configuration/AggregateProviderTest\.php\:31\:\:\$configuration has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: tests/lib/Configuration/AggregateProviderTest.php
-
-		-
-			message: '#^Property Ibexa\\Contracts\\FieldTypeRichText\\Configuration\\Provider@anonymous/tests/lib/Configuration/AggregateProviderTest\.php\:31\:\:\$name has no type specified\.$#'
-			identifier: missingType.property
 			count: 1
 			path: tests/lib/Configuration/AggregateProviderTest.php
 
@@ -1885,20 +1483,8 @@ parameters:
 			path: tests/lib/Configuration/Provider/AlloyEditorTest.php
 
 		-
-			message: '#^Call to an undefined method Ibexa\\FieldTypeRichText\\Configuration\\UI\\Mapper\\CustomStyle\|PHPUnit\\Framework\\MockObject\\MockObject\:\:expects\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: tests/lib/Configuration/Provider/BaseCustomTemplateProviderTestCase.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Configuration\\Provider\\BaseCustomTemplateProviderTestCase\:\:getExpectedCustomTemplatesConfiguration\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Configuration/Provider/BaseCustomTemplateProviderTestCase.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Configuration\\Provider\\BaseCustomTemplateProviderTestCase\:\:testGetConfiguration\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/Configuration/Provider/BaseCustomTemplateProviderTestCase.php
 
@@ -1921,32 +1507,14 @@ parameters:
 			path: tests/lib/Configuration/Provider/CustomStyleProviderTest.php
 
 		-
-			message: '#^Parameter \#2 \$customStyleConfigurationMapper of class Ibexa\\FieldTypeRichText\\Configuration\\Provider\\CustomStyle constructor expects Ibexa\\FieldTypeRichText\\Configuration\\UI\\Mapper\\CustomTemplateConfigMapper, Ibexa\\FieldTypeRichText\\Configuration\\UI\\Mapper\\CustomStyle\|PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/lib/Configuration/Provider/CustomStyleProviderTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Configuration\\Provider\\CustomTagProviderTest\:\:getExpectedCustomTemplatesConfiguration\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/Configuration/Provider/CustomTagProviderTest.php
 
 		-
-			message: '#^Parameter \#2 \$customTagConfigurationMapper of class Ibexa\\FieldTypeRichText\\Configuration\\Provider\\CustomTag constructor expects Ibexa\\FieldTypeRichText\\Configuration\\UI\\Mapper\\CustomTemplateConfigMapper, Ibexa\\FieldTypeRichText\\Configuration\\UI\\Mapper\\CustomStyle\|PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/lib/Configuration/Provider/CustomTagProviderTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Configuration\\UI\\Config\\Mapper\\CustomTagTest\:\:providerForTestMapConfig\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Configuration/UI/Config/Mapper/CustomTagTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Configuration\\UI\\Config\\Mapper\\CustomTagTest\:\:testMapConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/Configuration/UI/Config/Mapper/CustomTagTest.php
 
@@ -1967,12 +1535,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/Configuration/UI/Config/Mapper/CustomTagTest.php
-
-		-
-			message: '#^Call to an undefined method Symfony\\Contracts\\Translation\\TranslatorInterface\:\:expects\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: tests/lib/Configuration/UI/Config/Mapper/OnlineEditorTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Configuration\\UI\\Config\\Mapper\\OnlineEditorTest\:\:getSemanticConfigurationForMapCssClassesConfiguration\(\) return type has no value type specified in iterable type array\.$#'
@@ -2011,18 +1573,6 @@ parameters:
 			path: tests/lib/Configuration/UI/Config/Mapper/OnlineEditorTest.php
 
 		-
-			message: '#^PHPDoc tag @var with type Symfony\\Contracts\\Translation\\TranslatorInterface is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: tests/lib/Configuration/UI/Config/Mapper/OnlineEditorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\Gateway\\DoctrineStorageTest\:\:testGetContentIds\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichText/Gateway/DoctrineStorageTest.php
-
-		-
 			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\Gateway\\DoctrineStorageTest\:\:\$storageGateway \(Ibexa\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorage\\Gateway\\DoctrineStorage\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
 			count: 1
@@ -2031,132 +1581,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:groupLinksData\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:providerForTestGetFieldData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:providerForTestStoreFieldData\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:providerForTestStoreFieldDataThrowsNotFoundException\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testGetFieldData\(\) has parameter \$linkIds with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testGetFieldData\(\) has parameter \$linkUrls with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testGetFieldData\(\) has parameter \$updatedXmlString with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testGetFieldData\(\) has parameter \$xmlString with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldData\(\) has parameter \$contentIds with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldData\(\) has parameter \$insertLinks with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldData\(\) has parameter \$isUpdated with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldData\(\) has parameter \$linkIds with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldData\(\) has parameter \$linkUrls with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldData\(\) has parameter \$remoteIds with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldData\(\) has parameter \$updatedXmlString with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldData\(\) has parameter \$xmlString with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldDataThrowsNotFoundException\(\) has parameter \$contentIds with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldDataThrowsNotFoundException\(\) has parameter \$insertLinks with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldDataThrowsNotFoundException\(\) has parameter \$linkIds with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldDataThrowsNotFoundException\(\) has parameter \$linkUrls with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldDataThrowsNotFoundException\(\) has parameter \$remoteIds with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:testStoreFieldDataThrowsNotFoundException\(\) has parameter \$xmlString with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
 
@@ -2173,140 +1597,14 @@ parameters:
 			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
 
 		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:\$gatewayMock \(Ibexa\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorage\\Gateway&PHPUnit\\Framework\\MockObject\\MockObject\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\RichTextStorageTest\:\:\$loggerMock \(PHPUnit\\Framework\\MockObject\\MockObject&Psr\\Log\\LoggerInterface\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
-			count: 1
-			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\SearchFieldTest\:\:getDataForTestGetIndexData\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/FieldType/RichText/SearchFieldTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:provideDataForGetName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:provideFieldTypeIdentifier\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:providerForTestAcceptValueInvalidFormat\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:providerForTestAcceptValueValidFormat\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:providerForTestGetName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:providerForTestValidate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testAcceptValueInvalidFormat\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testAcceptValueInvalidFormat\(\) has parameter \$input with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testAcceptValueInvalidType\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testAcceptValueValidFormat\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testAcceptValueValidFormat\(\) has parameter \$input with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testGetName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testGetName\(\) has parameter \$expectedName with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testGetName\(\) has parameter \$xmlString with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testGetRelations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testSettingsSchema\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testToPersistenceValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testValidate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testValidate\(\) has parameter \$expectedValidationErrors with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testValidatorConfigurationSchema\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/FieldType/RichTextTest.php
 
@@ -2335,76 +1633,10 @@ parameters:
 			path: tests/lib/FieldType/RichTextTest.php
 
 		-
-			message: '#^Call to method expects\(\) on an unknown class Ibexa\\FieldTypeRichText\\RichText\\Converter\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/Form/DataTransformer/RichTextTransformerTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class Ibexa\\FieldTypeRichText\\RichText\\InputHandlerInterface\.$#'
-			identifier: class.notFound
-			count: 2
-			path: tests/lib/Form/DataTransformer/RichTextTransformerTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Form\\DataTransformer\\RichTextTransformerTest\:\:dataProviderForReverseTransformTransformationFailedException\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Form/DataTransformer/RichTextTransformerTest.php
-
-		-
 			message: '#^Parameter \#2 \$actualXml of method PHPUnit\\Framework\\Assert\:\:assertXmlStringEqualsXmlString\(\) expects DOMDocument\|string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: tests/lib/Form/DataTransformer/RichTextTransformerTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\Form\\DataTransformer\\RichTextTransformerTest\:\:\$docbook2xhtml5editConverter \(Ibexa\\FieldTypeRichText\\RichText\\Converter&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept Ibexa\\Contracts\\FieldTypeRichText\\RichText\\Converter&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/lib/Form/DataTransformer/RichTextTransformerTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\Form\\DataTransformer\\RichTextTransformerTest\:\:\$docbook2xhtml5editConverter has unknown class Ibexa\\FieldTypeRichText\\RichText\\Converter as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/Form/DataTransformer/RichTextTransformerTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\Form\\DataTransformer\\RichTextTransformerTest\:\:\$inputHandler \(Ibexa\\FieldTypeRichText\\RichText\\InputHandlerInterface&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept Ibexa\\Contracts\\FieldTypeRichText\\RichText\\InputHandlerInterface&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/lib/Form/DataTransformer/RichTextTransformerTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\Form\\DataTransformer\\RichTextTransformerTest\:\:\$inputHandler has unknown class Ibexa\\FieldTypeRichText\\RichText\\InputHandlerInterface as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/Form/DataTransformer/RichTextTransformerTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class Ibexa\\FieldTypeRichText\\RichText\\Converter\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\REST\\FieldTypeProcessor\\RichTextProcessorTest\:\:testPostProcessValueHash\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\REST\\FieldTypeProcessor\\RichTextProcessorTest\:\:\$converter \(Ibexa\\FieldTypeRichText\\RichText\\Converter&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept Ibexa\\Contracts\\FieldTypeRichText\\RichText\\Converter&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\REST\\FieldTypeProcessor\\RichTextProcessorTest\:\:\$converter has unknown class Ibexa\\FieldTypeRichText\\RichText\\Converter as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\AggregateTest\:\:providerConvertWithLinkInCustomTag\(\) return type has no value type specified in iterable type array\.$#'
@@ -2443,168 +1675,6 @@ parameters:
 			path: tests/lib/RichText/Converter/LinkTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadContentLink\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadContentLink\(\) has parameter \$contentId with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadContentLink\(\) has parameter \$exception with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadContentLink\(\) has parameter \$input with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadContentLink\(\) has parameter \$logMessage with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadContentLink\(\) has parameter \$logType with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadContentLink\(\) has parameter \$output with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadLocationLink\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadLocationLink\(\) has parameter \$exception with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadLocationLink\(\) has parameter \$input with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadLocationLink\(\) has parameter \$locationId with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadLocationLink\(\) has parameter \$logMessage with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadLocationLink\(\) has parameter \$logType with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertBadLocationLink\(\) has parameter \$output with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertContentLink\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertContentLink\(\) has parameter \$contentId with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertContentLink\(\) has parameter \$input with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertContentLink\(\) has parameter \$output with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertContentLink\(\) has parameter \$urlResolved with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertLocationLink\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertLocationLink\(\) has parameter \$input with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertLocationLink\(\) has parameter \$locationId with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertLocationLink\(\) has parameter \$output with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testConvertLocationLink\(\) has parameter \$urlResolved with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testLink\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testLink\(\) has parameter \$input with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:testLink\(\) has parameter \$output with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
 			message: '#^Parameter \#1 \$locationService of class Ibexa\\FieldTypeRichText\\RichText\\Converter\\Link constructor expects Ibexa\\Contracts\\Core\\Repository\\LocationService, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
 			identifier: argument.type
 			count: 5
@@ -2632,12 +1702,6 @@ parameters:
 			message: '#^Call to method expects\(\) on an unknown class Ibexa\\FieldTypeRichText\\RichText\\RendererInterface\.$#'
 			identifier: class.notFound
 			count: 3
-			path: tests/lib/RichText/Converter/Render/EmbedTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\EmbedTest\:\:getConverter\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
 			path: tests/lib/RichText/Converter/Render/EmbedTest.php
 
 		-
@@ -2731,12 +1795,6 @@ parameters:
 			path: tests/lib/RichText/Converter/Render/TemplateTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:getConverter\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:getConverterMock\(\) has invalid return type Ibexa\\FieldTypeRichText\\RichText\\Converter\.$#'
 			identifier: class.notFound
 			count: 1
@@ -2769,12 +1827,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:provideConvertRenderValues\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:providerForTestConvert\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/RichText/Converter/Render/TemplateTest.php
 
@@ -2935,12 +1987,6 @@ parameters:
 			path: tests/lib/RichText/Converter/Xslt/BaseTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Xslt\\BaseTest\:\:testConvert\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Converter/Xslt/BaseTest.php
-
-		-
 			message: '#^Parameter \#1 \$source of method DOMDocument\:\:loadXML\(\) expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
@@ -3079,52 +2125,10 @@ parameters:
 			path: tests/lib/RichText/Converter/Xslt/Xhtml5ToDocbookTest.php
 
 		-
-			message: '#^Call to method expects\(\) on an unknown class Ibexa\\FieldTypeRichText\\RichText\\ValidatorInterface\.$#'
-			identifier: class.notFound
-			count: 3
-			path: tests/lib/RichText/InputHandlerTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\InputHandlerTest\:\:\$docbookValidator \(Ibexa\\FieldTypeRichText\\RichText\\ValidatorInterface&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept Ibexa\\Contracts\\FieldTypeRichText\\RichText\\ValidatorInterface&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: assign.propertyType
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''DOMDocument'' and DOMDocument will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
 			count: 1
-			path: tests/lib/RichText/InputHandlerTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\InputHandlerTest\:\:\$docbookValidator has unknown class Ibexa\\FieldTypeRichText\\RichText\\ValidatorInterface as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/InputHandlerTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\InputHandlerTest\:\:\$domDocumentFactory \(Ibexa\\FieldTypeRichText\\RichText\\DOMDocumentFactory\|PHPUnit\\Framework\\MockObject\\MockObject\) is never assigned PHPUnit\\Framework\\MockObject\\MockObject so it can be removed from the property type\.$#'
-			identifier: property.unusedType
-			count: 1
-			path: tests/lib/RichText/InputHandlerTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\InputHandlerTest\:\:\$inputHandler \(Ibexa\\FieldTypeRichText\\RichText\\InputHandler&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept Ibexa\\FieldTypeRichText\\RichText\\InputHandler\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/lib/RichText/InputHandlerTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\InputHandlerTest\:\:\$schemaValidator \(Ibexa\\FieldTypeRichText\\RichText\\ValidatorInterface&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept Ibexa\\Contracts\\FieldTypeRichText\\RichText\\ValidatorInterface&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/lib/RichText/InputHandlerTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\InputHandlerTest\:\:\$schemaValidator has unknown class Ibexa\\FieldTypeRichText\\RichText\\ValidatorInterface as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/InputHandlerTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Normalizer\\DocumentTypeDefinitionTest\:\:getNormalizer\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
+			path: tests/lib/RichText/DOMDocumentFactoryTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Normalizer\\DocumentTypeDefinitionTest\:\:getNormalizer\(\) has parameter \$documentElement with no type specified\.$#'
@@ -3145,42 +2149,6 @@ parameters:
 			path: tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Normalizer\\DocumentTypeDefinitionTest\:\:providerForTestNormalize\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Normalizer\\DocumentTypeDefinitionTest\:\:providerForTestRefuse\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Normalizer\\DocumentTypeDefinitionTest\:\:testAccept\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Normalizer\\DocumentTypeDefinitionTest\:\:testAcceptNoXmlDeclaration\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Normalizer\\DocumentTypeDefinitionTest\:\:testNormalize\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Normalizer\\DocumentTypeDefinitionTest\:\:testRefuse\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RelationProcessorTest\:\:dateProviderForGetRelations\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -3191,12 +2159,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/RichText/RelationProcessorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:getContentMock\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:getContentMock\(\) has parameter \$mainLocationId with no type specified\.$#'
@@ -3211,80 +2173,8 @@ parameters:
 			path: tests/lib/RichText/RendererTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:providerForTestRenderContentEmbedNotFound\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:providerForTestRenderContentWithTemplate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:providerForTestRenderLocationEmbedNotFound\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:providerForTestRenderLocationWithTemplate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:providerForTestRenderTagWithTemplate\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentEmbed\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentEmbedAccessDenied\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentEmbedHidden\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentEmbedNoTemplateConfigured\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentEmbedNoTemplateFound\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentEmbedNotFound\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentEmbedThrowsException\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentEmbedTrashed\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/RichText/RendererTest.php
 
@@ -3295,86 +2185,8 @@ parameters:
 			path: tests/lib/RichText/RendererTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentWithTemplate\(\) has parameter \$deniedException with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentWithTemplate\(\) has parameter \$isInline with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentWithTemplate\(\) has parameter \$loggerParams with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentWithTemplate\(\) has parameter \$renderResult with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentWithTemplate\(\) has parameter \$renderTemplate with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderContentWithTemplate\(\) has parameter \$templateEngineTemplate with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationEmbed\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationEmbedAccessDenied\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationEmbedInvisible\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationEmbedNoTemplateConfigured\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationEmbedNoTemplateFound\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationEmbedNotFound\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationEmbedThrowsException\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationWithTemplate\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/RichText/RendererTest.php
 
@@ -3385,56 +2197,8 @@ parameters:
 			path: tests/lib/RichText/RendererTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationWithTemplate\(\) has parameter \$deniedException with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationWithTemplate\(\) has parameter \$isInline with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationWithTemplate\(\) has parameter \$loggerParams with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationWithTemplate\(\) has parameter \$renderResult with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationWithTemplate\(\) has parameter \$renderTemplate with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderLocationWithTemplate\(\) has parameter \$templateEngineTemplate with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderTag\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderTagNoTemplateConfigured\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderTagNoTemplateFound\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/RichText/RendererTest.php
 
@@ -3445,38 +2209,8 @@ parameters:
 			path: tests/lib/RichText/RendererTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderTagWithTemplate\(\) has parameter \$isInline with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderTagWithTemplate\(\) has parameter \$loggerParams with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderTagWithTemplate\(\) has parameter \$renderResult with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderTagWithTemplate\(\) has parameter \$renderTemplate with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderTagWithTemplate\(\) has parameter \$tagName with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/RendererTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\RendererTest\:\:testRenderTagWithTemplate\(\) has parameter \$templateEngineTemplate with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: tests/lib/RichText/RendererTest.php
 
@@ -3499,104 +2233,14 @@ parameters:
 			path: tests/lib/RichText/Validator/CustomTagsValidatorTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\CustomTagsValidatorTest\:\:testValidateDocument\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/CustomTagsValidatorTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\CustomTagsValidatorTest\:\:testValidateDocument\(\) has parameter \$expectedErrors with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/RichText/Validator/CustomTagsValidatorTest.php
 
 		-
-			message: '#^Call to method validateDocument\(\) on an unknown class Ibexa\\FieldTypeRichText\\RichText\\ValidatorInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Validator/DocbookTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\DocbookTest\:\:getConversionValidator\(\) has invalid return type Ibexa\\FieldTypeRichText\\RichText\\ValidatorInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Validator/DocbookTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\DocbookTest\:\:providerForTestValidate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/DocbookTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\DocbookTest\:\:testValidate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/DocbookTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\DocbookTest\:\:testValidate\(\) has parameter \$expectedErrors with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Validator/DocbookTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\DocbookTest\:\:testValidate\(\) has parameter \$input with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Validator/DocbookTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\DocbookTest\:\:\$validator \(Ibexa\\FieldTypeRichText\\RichText\\ValidatorInterface\) does not accept Ibexa\\FieldTypeRichText\\RichText\\Validator\\Validator\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/lib/RichText/Validator/DocbookTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\DocbookTest\:\:\$validator has unknown class Ibexa\\FieldTypeRichText\\RichText\\ValidatorInterface as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Validator/DocbookTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class Ibexa\\FieldTypeRichText\\FieldType\\RichText\\InternalLinkValidator\.$#'
-			identifier: class.notFound
-			count: 7
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Call to method validate\(\) on an unknown class Ibexa\\FieldTypeRichText\\FieldType\\RichText\\InternalLinkValidator\.$#'
-			identifier: class.notFound
-			count: 7
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Call to method validateDocument\(\) on an unknown class Ibexa\\FieldTypeRichText\\FieldType\\RichText\\InternalLinkValidator\.$#'
-			identifier: class.notFound
-			count: 7
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:assertContainsEzContentInvalidLinkError\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:assertContainsEzContentInvalidLinkError\(\) has parameter \$contentId with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:assertContainsEzContentInvalidLinkError\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:assertContainsEzLocationInvalidLinkError\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
 
@@ -3607,152 +2251,14 @@ parameters:
 			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:assertContainsEzLocationInvalidLinkError\(\) has parameter \$locationId with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:assertContainsEzRemoteInvalidLinkError\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:assertContainsEzRemoteInvalidLinkError\(\) has parameter \$contentId with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:assertContainsEzRemoteInvalidLinkError\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:createInputDocument\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:createInputDocument\(\) has parameter \$id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:createInputDocument\(\) has parameter \$scheme with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:getInternalLinkValidator\(\) has invalid return type Ibexa\\FieldTypeRichText\\FieldType\\RichText\\InternalLinkValidator\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:getInternalLinkValidator\(\) has parameter \$methods with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:getInternalLinkValidator\(\) should return Ibexa\\FieldTypeRichText\\FieldType\\RichText\\InternalLinkValidator&PHPUnit\\Framework\\MockObject\\MockObject but returns Ibexa\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidator&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:setupInternalLinkValidator\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateDocumentEzContentExistingContentId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateDocumentEzContentExistingLocationId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateDocumentEzContentNonExistingContentId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateDocumentEzContentNonExistingLocationId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateDocumentEzRemoteExistingId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateDocumentEzRemoteNonExistingId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateDocumentSkipMissingTargetId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateEzContentNonExistingContentId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateEzContentWithExistingContentId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateEzLocationWithExistingLocationId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateEzLocationWithNonExistingLocationId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateEzRemoteWithExistingRemoteId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateEzRemoteWithNonExistingRemoteId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Validator\\InternalLinkValidatorTest\:\:testValidateFailOnNotSupportedSchema\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1597,12 +1597,6 @@ parameters:
 			path: tests/lib/FieldType/RichText/RichTextStorageTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichText\\SearchFieldTest\:\:getDataForTestGetIndexData\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/FieldType/RichText/SearchFieldTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\FieldType\\RichTextTest\:\:testValidate\(\) has parameter \$expectedValidationErrors with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1610,12 +1604,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$converterMap of class Ibexa\\FieldTypeRichText\\RichText\\ConverterDispatcher constructor expects array\<Ibexa\\Contracts\\FieldTypeRichText\\RichText\\Converter\>, array\<string, null\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/lib/FieldType/RichTextTest.php
-
-		-
-			message: '#^Parameter \#1 \$transformationProcessor of method Ibexa\\Core\\FieldType\\FieldType\:\:setTransformationProcessor\(\) expects Ibexa\\Core\\Persistence\\TransformationProcessor, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
 			identifier: argument.type
 			count: 1
 			path: tests/lib/FieldType/RichTextTest.php
@@ -1663,27 +1651,9 @@ parameters:
 			path: tests/lib/RichText/Converter/LinkTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:providerLinkXmlSample\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\LinkTest\:\:providerLocationLink\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Parameter \#1 \$locationService of class Ibexa\\FieldTypeRichText\\RichText\\Converter\\Link constructor expects Ibexa\\Contracts\\Core\\Repository\\LocationService, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 5
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Parameter \#2 \$contentService of class Ibexa\\FieldTypeRichText\\RichText\\Converter\\Link constructor expects Ibexa\\Contracts\\Core\\Repository\\ContentService, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 5
 			path: tests/lib/RichText/Converter/LinkTest.php
 
 		-
@@ -1691,42 +1661,6 @@ parameters:
 			identifier: argument.type
 			count: 4
 			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Parameter \#3 \$router of class Ibexa\\FieldTypeRichText\\RichText\\Converter\\Link constructor expects Symfony\\Component\\Routing\\RouterInterface, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 5
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class Ibexa\\FieldTypeRichText\\RichText\\RendererInterface\.$#'
-			identifier: class.notFound
-			count: 3
-			path: tests/lib/RichText/Converter/Render/EmbedTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\EmbedTest\:\:getLoggerMock\(\) has invalid return type LoggerInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Converter/Render/EmbedTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\EmbedTest\:\:getLoggerMock\(\) should return LoggerInterface&PHPUnit\\Framework\\MockObject\\MockObject but returns PHPUnit\\Framework\\MockObject\\MockObject&Psr\\Log\\LoggerInterface\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/lib/RichText/Converter/Render/EmbedTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\EmbedTest\:\:getRendererMock\(\) has invalid return type Ibexa\\FieldTypeRichText\\RichText\\RendererInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Converter/Render/EmbedTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\EmbedTest\:\:getRendererMock\(\) should return Ibexa\\FieldTypeRichText\\RichText\\RendererInterface&PHPUnit\\Framework\\MockObject\\MockObject but returns Ibexa\\Contracts\\FieldTypeRichText\\RichText\\RendererInterface&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/lib/RichText/Converter/Render/EmbedTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\EmbedTest\:\:providerForTestConvert\(\) return type has no value type specified in iterable type array\.$#'
@@ -1765,60 +1699,6 @@ parameters:
 			path: tests/lib/RichText/Converter/Render/EmbedTest.php
 
 		-
-			message: '#^Parameter \#1 \$renderer of class Ibexa\\FieldTypeRichText\\RichText\\Converter\\Render\\Embed constructor expects Ibexa\\Contracts\\FieldTypeRichText\\RichText\\RendererInterface, Ibexa\\FieldTypeRichText\\RichText\\RendererInterface&PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/lib/RichText/Converter/Render/EmbedTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\EmbedTest\:\:\$loggerMock \(PHPUnit\\Framework\\MockObject\\MockObject&Psr\\Log\\LoggerInterface\) does not accept LoggerInterface&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/lib/RichText/Converter/Render/EmbedTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\EmbedTest\:\:\$rendererMock has unknown class Ibexa\\FieldTypeRichText\\RichText\\RendererInterface as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Converter/Render/EmbedTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class Ibexa\\FieldTypeRichText\\RichText\\Converter\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class Ibexa\\FieldTypeRichText\\RichText\\RendererInterface\.$#'
-			identifier: class.notFound
-			count: 3
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:getConverterMock\(\) has invalid return type Ibexa\\FieldTypeRichText\\RichText\\Converter\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:getConverterMock\(\) should return Ibexa\\FieldTypeRichText\\RichText\\Converter&PHPUnit\\Framework\\MockObject\\MockObject but returns Ibexa\\Contracts\\FieldTypeRichText\\RichText\\Converter&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:getRendererMock\(\) has invalid return type Ibexa\\FieldTypeRichText\\RichText\\RendererInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:getRendererMock\(\) should return Ibexa\\FieldTypeRichText\\RichText\\RendererInterface&PHPUnit\\Framework\\MockObject\\MockObject but returns Ibexa\\Contracts\\FieldTypeRichText\\RichText\\RendererInterface&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:provideConvertRenderValues\(\) has parameter \$expectedValues with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1846,36 +1726,6 @@ parameters:
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:withConsecutive\(\) invoked with unpacked array with possibly string key, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
 			count: 2
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Parameter \#1 \$converters of class Ibexa\\FieldTypeRichText\\RichText\\Converter\\Aggregate constructor expects array\<Ibexa\\Contracts\\FieldTypeRichText\\RichText\\Converter\>, array\<int, \(Ibexa\\FieldTypeRichText\\RichText\\Converter&PHPUnit\\Framework\\MockObject\\MockObject\)\|Ibexa\\FieldTypeRichText\\RichText\\Converter\\Render\\Template\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Parameter \#1 \$renderer of class Ibexa\\FieldTypeRichText\\RichText\\Converter\\Render\\Template constructor expects Ibexa\\Contracts\\FieldTypeRichText\\RichText\\RendererInterface, Ibexa\\FieldTypeRichText\\RichText\\RendererInterface&PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 2
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Parameter \#2 \$richTextConverter of class Ibexa\\FieldTypeRichText\\RichText\\Converter\\Render\\Template constructor expects Ibexa\\Contracts\\FieldTypeRichText\\RichText\\Converter, Ibexa\\FieldTypeRichText\\RichText\\Converter&PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:\$converterMock has unknown class Ibexa\\FieldTypeRichText\\RichText\\Converter as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/lib/RichText/Converter/Render/TemplateTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\TemplateTest\:\:\$rendererMock has unknown class Ibexa\\FieldTypeRichText\\RichText\\RendererInterface as its type\.$#'
-			identifier: class.notFound
-			count: 1
 			path: tests/lib/RichText/Converter/Render/TemplateTest.php
 
 		-
@@ -2263,12 +2113,6 @@ parameters:
 			path: tests/lib/RichText/Validator/InternalLinkValidatorTest.php
 
 		-
-			message: '#^Call to method expects\(\) on an unknown class Ibexa\\FieldTypeRichText\\RichText\\InputHandlerInterface\.$#'
-			identifier: class.notFound
-			count: 6
-			path: tests/lib/Validator/Constraints/RichTextValidatorTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Validator\\Constraints\\RichTextValidatorTest\:\:createInvalidXmlExceptionMock\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2283,17 +2127,5 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\Validator\\Constraints\\RichTextValidatorTest\:\:fetchErrorMessages\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Validator/Constraints/RichTextValidatorTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\Validator\\Constraints\\RichTextValidatorTest\:\:\$inputHandler \(Ibexa\\FieldTypeRichText\\RichText\\InputHandlerInterface&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept Ibexa\\Contracts\\FieldTypeRichText\\RichText\\InputHandlerInterface&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/lib/Validator/Constraints/RichTextValidatorTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\FieldTypeRichText\\Validator\\Constraints\\RichTextValidatorTest\:\:\$inputHandler has unknown class Ibexa\\FieldTypeRichText\\RichText\\InputHandlerInterface as its type\.$#'
-			identifier: class.notFound
 			count: 1
 			path: tests/lib/Validator/Constraints/RichTextValidatorTest.php

--- a/src/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
+++ b/src/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RichTextHtml5ConverterPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->hasDefinition('ibexa.richtext.converter.output.xhtml5')) {
             $html5OutputConverterDefinition = $container->getDefinition('ibexa.richtext.converter.output.xhtml5');
@@ -68,7 +68,7 @@ class RichTextHtml5ConverterPass implements CompilerPassInterface
      *
      * @return \Symfony\Component\DependencyInjection\Reference[]
      */
-    protected function sortConverters(array $convertersByPriority)
+    protected function sortConverters(array $convertersByPriority): array
     {
         ksort($convertersByPriority);
 

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -135,7 +135,7 @@ class Configuration extends SiteAccessConfiguration
                                 ->end()
                                 ->validate()
                                     ->ifTrue(
-                                        static function ($v) {
+                                        static function ($v): bool {
                                             return $v['type'] === 'choice' && !empty($v['required']) && empty($v['choices']);
                                         }
                                     )
@@ -143,7 +143,7 @@ class Configuration extends SiteAccessConfiguration
                                 ->end()
                                 ->validate()
                                     ->ifTrue(
-                                        static function ($v) {
+                                        static function ($v): bool {
                                             return !empty($v['choices']) && $v['type'] !== 'choice';
                                         }
                                     )

--- a/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -228,13 +228,7 @@ class RichText extends AbstractFieldTypeParser
         $this->buildOnlineEditorConfiguration($nodeBuilder);
     }
 
-    /**
-     * @param string $info
-     * @param string $example
-     *
-     * @return \Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition
-     */
-    protected function getTemplateNodeDefinition(string $info, string|array $example): ScalarNodeDefinition
+    protected function getTemplateNodeDefinition(string $info, string $example): ScalarNodeDefinition
     {
         $templateNodeDefinition = new ScalarNodeDefinition('template');
         $templateNodeDefinition

--- a/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -56,7 +56,7 @@ class RichText extends AbstractFieldTypeParser
      *
      * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
      */
-    public function addFieldTypeSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addFieldTypeSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('embed')
@@ -234,7 +234,7 @@ class RichText extends AbstractFieldTypeParser
      *
      * @return \Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition
      */
-    protected function getTemplateNodeDefinition($info, $example)
+    protected function getTemplateNodeDefinition(string $info, string|array $example): ScalarNodeDefinition
     {
         $templateNodeDefinition = new ScalarNodeDefinition('template');
         $templateNodeDefinition
@@ -246,7 +246,7 @@ class RichText extends AbstractFieldTypeParser
         return $templateNodeDefinition;
     }
 
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
         if (!empty($scopeSettings['fieldtypes'])) {
             // Workaround to be able to use Contextualizer::mapConfigArray() which only supports first level entries.
@@ -284,7 +284,7 @@ class RichText extends AbstractFieldTypeParser
         }
     }
 
-    public function postMap(array $config, ContextualizerInterface $contextualizer)
+    public function postMap(array $config, ContextualizerInterface $contextualizer): void
     {
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.custom_tags', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.custom_styles', $config);
@@ -308,7 +308,7 @@ class RichText extends AbstractFieldTypeParser
      */
     private function buildOnlineEditorConfiguration(NodeBuilder $nodeBuilder): void
     {
-        $invalidChoiceCallback = static function (array $v) {
+        $invalidChoiceCallback = static function (array $v): void {
             $message = sprintf(
                 'The default value must be one of the possible choices: %s, instead of "%s" ',
                 implode(', ', $v[self::CHOICES_NODE_KEY]),
@@ -323,7 +323,7 @@ class RichText extends AbstractFieldTypeParser
                 ->useAttributeAsKey(self::ELEMENT_NODE_KEY)
                 ->arrayPrototype()
                     ->validate()
-                        ->ifTrue(static function (array $v) {
+                        ->ifTrue(static function (array $v): bool {
                             return !empty($v[self::DEFAULT_VALUE_NODE_KEY])
                                 && !in_array($v[self::DEFAULT_VALUE_NODE_KEY], $v[self::CHOICES_NODE_KEY]);
                         })
@@ -396,7 +396,7 @@ class RichText extends AbstractFieldTypeParser
      */
     private function getAttributesValidatorCallback(callable $invalidChoiceCallback): callable
     {
-        return static function (array $v) use ($invalidChoiceCallback) {
+        return static function (array $v) use ($invalidChoiceCallback): array {
             if ($v[self::ATTRIBUTE_TYPE_NODE_KEY] === self::ATTRIBUTE_TYPE_CHOICE
                 && !empty($v[self::DEFAULT_VALUE_NODE_KEY])
                 && !in_array($v[self::DEFAULT_VALUE_NODE_KEY], $v[self::CHOICES_NODE_KEY])

--- a/src/bundle/DependencyInjection/IbexaFieldTypeRichTextExtension.php
+++ b/src/bundle/DependencyInjection/IbexaFieldTypeRichTextExtension.php
@@ -53,7 +53,7 @@ class IbexaFieldTypeRichTextExtension extends Extension implements PrependExtens
      *
      * @throws \Exception
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $settingsLoader = new Loader\YamlFileLoader(
             $container,
@@ -141,7 +141,7 @@ class IbexaFieldTypeRichTextExtension extends Extension implements PrependExtens
      *
      * @throws \Exception
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $this->prependIbexaConfiguration($container);
         $this->prependEzRichTextConfiguration($container);

--- a/src/bundle/IbexaFieldTypeRichTextBundle.php
+++ b/src/bundle/IbexaFieldTypeRichTextBundle.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class IbexaFieldTypeRichTextBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 
@@ -33,7 +33,7 @@ class IbexaFieldTypeRichTextBundle extends Bundle
         $this->registerConfigParser($container);
     }
 
-    public function registerConfigParser(ContainerBuilder $container)
+    public function registerConfigParser(ContainerBuilder $container): void
     {
         $this->getCoreExtension($container)->addConfigParser(new RichText());
     }

--- a/src/bundle/Templating/Twig/Extension/RichTextConfigurationExtension.php
+++ b/src/bundle/Templating/Twig/Extension/RichTextConfigurationExtension.php
@@ -19,8 +19,7 @@ use Twig\Extension\GlobalsInterface;
  */
 final class RichTextConfigurationExtension extends AbstractExtension implements GlobalsInterface
 {
-    /** @var \Ibexa\Contracts\FieldTypeRichText\Configuration\ProviderService */
-    private $configurationProvider;
+    private ProviderService $configurationProvider;
 
     public function __construct(ProviderService $configurationProvider)
     {

--- a/src/bundle/Templating/Twig/Extension/RichTextConverterExtension.php
+++ b/src/bundle/Templating/Twig/Extension/RichTextConverterExtension.php
@@ -9,17 +9,16 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\FieldTypeRichText\Templating\Twig\Extension;
 
 use DOMDocument;
+use Ibexa\Contracts\FieldTypeRichText\RichText\Converter;
 use Ibexa\Contracts\FieldTypeRichText\RichText\Converter as RichTextConverterInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 class RichTextConverterExtension extends AbstractExtension
 {
-    /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter */
-    private $richTextOutputConverter;
+    private Converter $richTextOutputConverter;
 
-    /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter */
-    private $richTextEditConverter;
+    private Converter $richTextEditConverter;
 
     public function __construct(
         RichTextConverterInterface $richTextOutputConverter,

--- a/src/lib/Configuration/AggregateProvider.php
+++ b/src/lib/Configuration/AggregateProvider.php
@@ -18,7 +18,7 @@ use Ibexa\Contracts\FieldTypeRichText\Configuration\ProviderService;
 final class AggregateProvider implements ProviderService
 {
     /** @var \Ibexa\Contracts\FieldTypeRichText\Configuration\Provider[]|iterable */
-    private $providers;
+    private iterable $providers;
 
     /**
      * @param \Ibexa\Contracts\FieldTypeRichText\Configuration\Provider[] $providers

--- a/src/lib/Configuration/Provider/AlloyEditor.php
+++ b/src/lib/Configuration/Provider/AlloyEditor.php
@@ -20,14 +20,11 @@ use Ibexa\FieldTypeRichText\Configuration\UI\Mapper\OnlineEditorConfigMapper;
  */
 final class AlloyEditor implements Provider
 {
-    /** @var array */
-    private $alloyEditorConfiguration;
+    private array $alloyEditorConfiguration;
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /** @var \Ibexa\FieldTypeRichText\Configuration\UI\Mapper\OnlineEditorConfigMapper */
-    private $onlineEditorConfigMapper;
+    private OnlineEditorConfigMapper $onlineEditorConfigMapper;
 
     public function __construct(
         array $alloyEditorConfiguration,

--- a/src/lib/Configuration/Provider/CKEditor.php
+++ b/src/lib/Configuration/Provider/CKEditor.php
@@ -22,11 +22,9 @@ final class CKEditor implements Provider
     private const SEPARATOR = '|';
     private const CUSTOM_STYLE_INLINE = 'ibexaCustomStyleInline';
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /** @var array */
-    private $customStylesConfiguration;
+    private array $customStylesConfiguration;
 
     public function __construct(
         ConfigResolverInterface $configResolver,

--- a/src/lib/Configuration/Provider/CustomStyle.php
+++ b/src/lib/Configuration/Provider/CustomStyle.php
@@ -19,11 +19,10 @@ use Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTemplateConfigMapper;
  */
 final class CustomStyle implements Provider
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     /** @var \Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomStyle */
-    private $customStyleConfigurationMapper;
+    private CustomTemplateConfigMapper $customStyleConfigurationMapper;
 
     public function __construct(
         ConfigResolverInterface $configResolver,

--- a/src/lib/Configuration/UI/Mapper/CustomStyle.php
+++ b/src/lib/Configuration/UI/Mapper/CustomStyle.php
@@ -19,17 +19,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 final class CustomStyle implements CustomTemplateConfigMapper
 {
-    /** @var array */
-    private $customStylesConfiguration;
+    private array $customStylesConfiguration;
 
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    private $translator;
+    private TranslatorInterface $translator;
 
-    /** @var \Symfony\Component\Asset\Packages */
-    private $packages;
+    private Packages $packages;
 
-    /** @var string */
-    private $translationDomain;
+    private string $translationDomain;
 
     public function __construct(
         array $customStylesConfiguration,

--- a/src/lib/Configuration/UI/Mapper/OnlineEditor.php
+++ b/src/lib/Configuration/UI/Mapper/OnlineEditor.php
@@ -20,8 +20,7 @@ final class OnlineEditor implements OnlineEditorConfigMapper
     /** @var \Symfony\Component\Translation\TranslatorInterface */
     private $translator;
 
-    /** @var string */
-    private $translationDomain;
+    private string $translationDomain;
 
     public function __construct(TranslatorInterface $translator, string $translationDomain)
     {

--- a/src/lib/FieldType/RichText/RichTextStorage.php
+++ b/src/lib/FieldType/RichText/RichTextStorage.php
@@ -179,11 +179,13 @@ class RichTextStorage extends GatewayBasedStorage
         $field->value->data = $document->saveXML();
     }
 
-    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds): void
+    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds): bool
     {
         foreach ($fieldIds as $fieldId) {
             $this->gateway->unlinkUrl($fieldId, $versionInfo->versionNo);
         }
+
+        return true;
     }
 
     /**

--- a/src/lib/FieldType/RichText/RichTextStorage.php
+++ b/src/lib/FieldType/RichText/RichTextStorage.php
@@ -19,10 +19,7 @@ use Psr\Log\LoggerInterface;
 
 class RichTextStorage extends GatewayBasedStorage
 {
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    protected $logger;
+    protected ?LoggerInterface $logger;
 
     /**
      * @var \Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage\Gateway
@@ -129,7 +126,7 @@ class RichTextStorage extends GatewayBasedStorage
     /**
      * Modifies $field if needed, using external data (like for Urls).
      */
-    public function getFieldData(VersionInfo $versionInfo, Field $field)
+    public function getFieldData(VersionInfo $versionInfo, Field $field): void
     {
         $document = new DOMDocument();
         $document->loadXML($field->value->data);
@@ -182,7 +179,7 @@ class RichTextStorage extends GatewayBasedStorage
         $field->value->data = $document->saveXML();
     }
 
-    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds)
+    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds): void
     {
         foreach ($fieldIds as $fieldId) {
             $this->gateway->unlinkUrl($fieldId, $versionInfo->versionNo);

--- a/src/lib/FieldType/RichText/RichTextStorage/Gateway.php
+++ b/src/lib/FieldType/RichText/RichTextStorage/Gateway.php
@@ -17,10 +17,7 @@ use Ibexa\Core\FieldType\Url\UrlStorage\Gateway as UrlGateway;
  */
 abstract class Gateway extends StorageGateway
 {
-    /**
-     * @var \Ibexa\Core\FieldType\Url\UrlStorage\Gateway
-     */
-    protected $urlGateway;
+    protected UrlGateway $urlGateway;
 
     public function __construct(UrlGateway $urlGateway)
     {
@@ -85,7 +82,7 @@ abstract class Gateway extends StorageGateway
      * @param int|string $fieldId
      * @param int $versionNo
      */
-    public function linkUrl($urlId, $fieldId, $versionNo)
+    public function linkUrl($urlId, $fieldId, $versionNo): void
     {
         $this->urlGateway->linkUrl($urlId, $fieldId, $versionNo);
     }
@@ -97,7 +94,7 @@ abstract class Gateway extends StorageGateway
      * @param int $versionNo
      * @param int[] $excludeUrlIds
      */
-    public function unlinkUrl($fieldId, $versionNo, array $excludeUrlIds = [])
+    public function unlinkUrl($fieldId, $versionNo, array $excludeUrlIds = []): void
     {
         $this->urlGateway->unlinkUrl($fieldId, $versionNo, $excludeUrlIds);
     }

--- a/src/lib/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
+++ b/src/lib/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
@@ -14,10 +14,7 @@ use Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage\Gateway;
 
 class DoctrineStorage extends Gateway
 {
-    /**
-     * @var \Doctrine\DBAL\Connection
-     */
-    protected $connection;
+    protected Connection $connection;
 
     public function __construct(UrlGateway $urlGateway, Connection $connection)
     {
@@ -34,7 +31,7 @@ class DoctrineStorage extends Gateway
      *
      * @return int[] An array of Content ids, with remote ids as keys
      */
-    public function getContentIds(array $remoteIds)
+    public function getContentIds(array $remoteIds): array
     {
         $objectRemoteIdMap = [];
 

--- a/src/lib/FieldType/RichText/Type.php
+++ b/src/lib/FieldType/RichText/Type.php
@@ -27,10 +27,7 @@ use RuntimeException;
  */
 class Type extends FieldType implements TranslationContainerInterface
 {
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\InputHandlerInterface
-     */
-    private $inputHandler;
+    private InputHandlerInterface $inputHandler;
 
     private TextExtractorInterface $textExtractor;
 
@@ -165,7 +162,7 @@ class Type extends FieldType implements TranslationContainerInterface
      */
     public function validate(FieldDefinition $fieldDefinition, SPIValue $value)
     {
-        return array_map(static function ($error) {
+        return array_map(static function (string $error): ValidationError {
             return new ValidationError("Validation of XML content failed:\n" . $error, null, [], 'xml');
         }, $this->inputHandler->validate($value->xml));
     }

--- a/src/lib/Form/DataTransformer/RichTextTransformer.php
+++ b/src/lib/Form/DataTransformer/RichTextTransformer.php
@@ -19,20 +19,11 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 
 class RichTextTransformer implements DataTransformerInterface
 {
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory
-     */
-    private $domDocumentFactory;
+    private DOMDocumentFactory $domDocumentFactory;
 
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\InputHandlerInterface
-     */
-    private $inputHandler;
+    private InputHandlerInterface $inputHandler;
 
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter
-     */
-    private $docbook2xhtml5editConverter;
+    private Converter $docbook2xhtml5editConverter;
 
     /**
      * @param \Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory $domDocumentFactory

--- a/src/lib/Form/DataTransformer/RichTextValueTransformer.php
+++ b/src/lib/Form/DataTransformer/RichTextValueTransformer.php
@@ -18,13 +18,12 @@ use Symfony\Component\Form\DataTransformerInterface;
  */
 class RichTextValueTransformer implements DataTransformerInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldType */
-    private $fieldType;
+    private FieldType $fieldType;
 
     /**
      * @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter Converter
      */
-    protected $docbookToXhtml5EditConverter;
+    protected Converter $docbookToXhtml5EditConverter;
 
     public function __construct(FieldType $fieldType, Converter $docbookToXhtml5EditConverter)
     {

--- a/src/lib/Form/Mapper/RichTextFormMapper.php
+++ b/src/lib/Form/Mapper/RichTextFormMapper.php
@@ -16,7 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RichTextFormMapper implements FieldValueFormMapperInterface
 {
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
@@ -36,7 +36,7 @@ class RichTextFormMapper implements FieldValueFormMapperInterface
     /**
      * Fake method to set the translation domain for the extractor.
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/lib/Form/Type/RichTextFieldType.php
+++ b/src/lib/Form/Type/RichTextFieldType.php
@@ -20,11 +20,9 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class RichTextFieldType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    protected $fieldTypeService;
+    protected FieldTypeService $fieldTypeService;
 
-    /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter */
-    protected $docbookToXhtml5EditConverter;
+    protected Converter $docbookToXhtml5EditConverter;
 
     public function __construct(FieldTypeService $fieldTypeService, Converter $docbookToXhtml5EditConverter)
     {
@@ -32,7 +30,7 @@ class RichTextFieldType extends AbstractType
         $this->docbookToXhtml5EditConverter = $docbookToXhtml5EditConverter;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/RichTextType.php
+++ b/src/lib/Form/Type/RichTextType.php
@@ -20,20 +20,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RichTextType extends AbstractType
 {
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory
-     */
-    private $domDocumentFactory;
+    private DOMDocumentFactory $domDocumentFactory;
 
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\InputHandlerInterface
-     */
-    private $inputHandler;
+    private InputHandlerInterface $inputHandler;
 
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter
-     */
-    private $docbookToXhtml5EditConverter;
+    private Converter $docbookToXhtml5EditConverter;
 
     /**
      * @param \Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory $domDocumentFactory

--- a/src/lib/Persistence/Legacy/RichTextFieldValueConverter.php
+++ b/src/lib/Persistence/Legacy/RichTextFieldValueConverter.php
@@ -23,7 +23,7 @@ class RichTextFieldValueConverter implements Converter
      * @param \Ibexa\Contracts\Core\Persistence\Content\FieldValue $value
      * @param \Ibexa\Core\Persistence\Legacy\Content\StorageFieldValue $storageFieldValue
      */
-    public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
+    public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue): void
     {
         $storageFieldValue->dataText = $value->data;
         $storageFieldValue->sortKeyString = $value->sortKey;
@@ -35,7 +35,7 @@ class RichTextFieldValueConverter implements Converter
      * @param \Ibexa\Core\Persistence\Legacy\Content\StorageFieldValue $value
      * @param \Ibexa\Contracts\Core\Persistence\Content\FieldValue $fieldValue
      */
-    public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue)
+    public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue): void
     {
         $fieldValue->data = $value->dataText ?: Value::EMPTY_VALUE;
         $fieldValue->sortKey = $value->sortKeyString;
@@ -47,7 +47,7 @@ class RichTextFieldValueConverter implements Converter
      * @param \Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition $fieldDefinition
      * @param \Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDefinition
      */
-    public function toStorageFieldDefinition(FieldDefinition $fieldDefinition, StorageFieldDefinition $storageDefinition)
+    public function toStorageFieldDefinition(FieldDefinition $fieldDefinition, StorageFieldDefinition $storageDefinition): void
     {
         // Nothing to store
     }
@@ -58,7 +58,7 @@ class RichTextFieldValueConverter implements Converter
      * @param \Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDefinition
      * @param \Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition $fieldDefinition
      */
-    public function toFieldDefinition(StorageFieldDefinition $storageDefinition, FieldDefinition $fieldDefinition)
+    public function toFieldDefinition(StorageFieldDefinition $storageDefinition, FieldDefinition $fieldDefinition): void
     {
         $fieldDefinition->defaultValue->data = Value::EMPTY_VALUE;
     }

--- a/src/lib/REST/FieldTypeProcessor/RichTextProcessor.php
+++ b/src/lib/REST/FieldTypeProcessor/RichTextProcessor.php
@@ -14,10 +14,7 @@ use Ibexa\Contracts\Rest\FieldTypeProcessor;
 
 class RichTextProcessor extends FieldTypeProcessor
 {
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter
-     */
-    protected $docbookToXhtml5EditConverter;
+    protected Converter $docbookToXhtml5EditConverter;
 
     public function __construct(Converter $docbookToXhtml5EditConverter)
     {

--- a/src/lib/RichText/Converter/Link.php
+++ b/src/lib/RichText/Converter/Link.php
@@ -22,25 +22,13 @@ use Symfony\Component\Routing\RouterInterface;
 
 class Link implements Converter
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\LocationService
-     */
-    protected $locationService;
+    protected LocationService $locationService;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentService
-     */
-    protected $contentService;
+    protected ContentService $contentService;
 
-    /**
-     * @var \Symfony\Component\Routing\RouterInterface
-     */
-    protected $router;
+    protected RouterInterface $router;
 
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    protected $logger;
+    protected ?LoggerInterface $logger;
 
     public function __construct(
         LocationService $locationService,

--- a/src/lib/RichText/Converter/ProgramListing.php
+++ b/src/lib/RichText/Converter/ProgramListing.php
@@ -27,7 +27,7 @@ class ProgramListing implements Converter
      *
      * @return \DOMDocument
      */
-    public function convert(DOMDocument $document)
+    public function convert(DOMDocument $document): DOMDocument
     {
         $xpath = new DOMXPath($document);
         $xpathExpression = '//ns:pre';

--- a/src/lib/RichText/Converter/Render.php
+++ b/src/lib/RichText/Converter/Render.php
@@ -18,10 +18,7 @@ use Ibexa\Contracts\FieldTypeRichText\RichText\RendererInterface;
  */
 abstract class Render
 {
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\RendererInterface
-     */
-    protected $renderer;
+    protected RendererInterface $renderer;
 
     public function __construct(RendererInterface $renderer)
     {

--- a/src/lib/RichText/Converter/Render/Embed.php
+++ b/src/lib/RichText/Converter/Render/Embed.php
@@ -22,10 +22,7 @@ use Psr\Log\LoggerInterface;
  */
 class Embed extends Render implements Converter
 {
-    /**
-     * @var \Psr\Log\LoggerInterface|null
-     */
-    protected $logger;
+    protected ?LoggerInterface $logger;
 
     /**
      * Maps embed tag names to their default views.
@@ -121,7 +118,7 @@ class Embed extends Render implements Converter
      *
      * @return array
      */
-    protected function extractParameters(DOMElement $embed, $tagName)
+    protected function extractParameters(DOMElement $embed, $tagName): array
     {
         if (!$viewType = $embed->getAttribute('view')) {
             $viewType = $this->tagDefaultViewMap[$tagName];
@@ -168,7 +165,7 @@ class Embed extends Render implements Converter
      *
      * @return array
      */
-    protected function extractLinkParameters(DOMElement $embed)
+    protected function extractLinkParameters(DOMElement $embed): ?array
     {
         $links = $embed->getElementsByTagName('ezlink');
 
@@ -307,7 +304,7 @@ class Embed extends Render implements Converter
      *
      * @return \DOMDocument
      */
-    public function convert(DOMDocument $document)
+    public function convert(DOMDocument $document): DOMDocument
     {
         $this->processTag($document, 'ezembed', false);
         $this->processTag($document, 'ezembedinline', true);

--- a/src/lib/RichText/Converter/Render/Template.php
+++ b/src/lib/RichText/Converter/Render/Template.php
@@ -25,15 +25,9 @@ class Template extends Render implements Converter
 {
     public const LITERAL_LAYOUT_LINE_BREAK = "\n";
 
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter
-     */
-    private $richTextConverter;
+    private Converter $richTextConverter;
 
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * RichText Template converter constructor.
@@ -60,7 +54,7 @@ class Template extends Render implements Converter
      *
      * @return \DOMDocument
      */
-    public function convert(DOMDocument $document)
+    public function convert(DOMDocument $document): DOMDocument
     {
         $xpath = new DOMXPath($document);
         $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
@@ -141,7 +135,7 @@ class Template extends Render implements Converter
      *
      * @return string
      */
-    protected function getCustomTemplateContent(DOMNode $node)
+    protected function getCustomTemplateContent(DOMNode $node): string
     {
         $innerDoc = new DOMDocument();
 

--- a/src/lib/RichText/ConverterDispatcher.php
+++ b/src/lib/RichText/ConverterDispatcher.php
@@ -40,7 +40,7 @@ class ConverterDispatcher
      * @param string $namespace
      * @param \Ibexa\Contracts\FieldTypeRichText\RichText\Converter|null $converter
      */
-    public function addConverter($namespace, Converter $converter = null)
+    public function addConverter($namespace, Converter $converter = null): void
     {
         $this->mapping[$namespace] = $converter;
     }

--- a/src/lib/RichText/Exception/InvalidXmlException.php
+++ b/src/lib/RichText/Exception/InvalidXmlException.php
@@ -16,7 +16,7 @@ class InvalidXmlException extends InvalidArgumentException
     /**
      * @var \LibXMLError[]
      */
-    private $errors;
+    private array $errors;
 
     /**
      * @param string $argumentName

--- a/src/lib/RichText/InputHandler.php
+++ b/src/lib/RichText/InputHandler.php
@@ -16,35 +16,17 @@ use Ibexa\FieldTypeRichText\FieldType\RichText\Value;
 
 class InputHandler implements InputHandlerInterface
 {
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory
-     */
-    private $domDocumentFactory;
+    private DOMDocumentFactory $domDocumentFactory;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\ConverterDispatcher
-     */
-    private $converter;
+    private ConverterDispatcher $converter;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\Normalizer
-     */
-    private $normalizer;
+    private Normalizer $normalizer;
 
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\ValidatorInterface
-     */
-    private $schemaValidator;
+    private ValidatorInterface $schemaValidator;
 
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\ValidatorInterface
-     */
-    private $docbookValidator;
+    private ValidatorInterface $docbookValidator;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\RelationProcessor
-     */
-    private $relationProcessor;
+    private RelationProcessor $relationProcessor;
 
     /**
      * @param \Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory $domDocumentFactory

--- a/src/lib/RichText/Normalizer/Aggregate.php
+++ b/src/lib/RichText/Normalizer/Aggregate.php
@@ -20,7 +20,7 @@ class Aggregate extends Normalizer
      *
      * @var \Ibexa\FieldTypeRichText\RichText\Normalizer[]
      */
-    protected $normalizers = [];
+    protected array $normalizers;
 
     /**
      * @param \Ibexa\FieldTypeRichText\RichText\Normalizer[] $normalizers An array of Normalizers, sorted by priority
@@ -39,7 +39,7 @@ class Aggregate extends Normalizer
      *
      * @return bool
      */
-    public function accept($input)
+    public function accept($input): bool
     {
         return true;
     }

--- a/src/lib/RichText/Normalizer/DocumentTypeDefinition.php
+++ b/src/lib/RichText/Normalizer/DocumentTypeDefinition.php
@@ -42,10 +42,8 @@ class DocumentTypeDefinition extends Normalizer
 
     /**
      * Holds computed regular expression pattern for matching and replacement.
-     *
-     * @var string
      */
-    private $expression;
+    private ?string $expression = null;
 
     public function __construct($documentElement, $namespace, $dtdPath)
     {
@@ -62,7 +60,7 @@ class DocumentTypeDefinition extends Normalizer
      *
      * @return bool
      */
-    public function accept($input)
+    public function accept($input): bool
     {
         if (preg_match($this->getExpression(), $input, $matches)) {
             return true;
@@ -78,7 +76,7 @@ class DocumentTypeDefinition extends Normalizer
      *
      * @return string
      */
-    public function normalize($input)
+    public function normalize($input): ?string
     {
         return preg_replace(
             $this->getExpression(),

--- a/src/lib/RichText/Renderer.php
+++ b/src/lib/RichText/Renderer.php
@@ -32,49 +32,25 @@ class Renderer implements RendererInterface
     /**
      * @var \Ibexa\Core\Repository\Repository
      */
-    protected $repository;
+    protected Repository $repository;
 
     private PermissionResolver $permissionResolver;
 
-    /**
-     * @var string
-     */
-    protected $tagConfigurationNamespace;
+    protected string $tagConfigurationNamespace;
 
-    /**
-     * @var string
-     */
-    protected $styleConfigurationNamespace;
+    protected string $styleConfigurationNamespace;
 
-    /**
-     * @var string
-     */
-    protected $embedConfigurationNamespace;
+    protected string $embedConfigurationNamespace;
 
-    /**
-     * @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    protected $configResolver;
+    protected ConfigResolverInterface $configResolver;
 
-    /**
-     * @var \Twig\Environment
-     */
-    protected $templateEngine;
+    protected Environment $templateEngine;
 
-    /**
-     * @var \Psr\Log\LoggerInterface|null
-     */
-    protected $logger;
+    protected LoggerInterface $logger;
 
-    /**
-     * @var array
-     */
-    private $customTagsConfiguration;
+    private array $customTagsConfiguration;
 
-    /**
-     * @var array
-     */
-    private $customStylesConfiguration;
+    private array $customStylesConfiguration;
 
     public function __construct(
         Repository $repository,
@@ -110,7 +86,7 @@ class Renderer implements RendererInterface
         try {
             /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content $content */
             $content = $this->repository->sudo(
-                static function (Repository $repository) use ($contentId) {
+                static function (Repository $repository) use ($contentId): \Ibexa\Contracts\Core\Repository\Values\Content\Content {
                     return $repository->getContentService()->loadContent((int)$contentId);
                 }
             );
@@ -273,7 +249,7 @@ class Renderer implements RendererInterface
      *
      * @return string
      */
-    protected function render($templateReference, array $parameters)
+    protected function render($templateReference, array $parameters): string
     {
         return $this->templateEngine->render(
             $templateReference,
@@ -326,7 +302,7 @@ class Renderer implements RendererInterface
      *
      * @return string|null
      */
-    protected function getTagTemplateName($identifier, $isInline)
+    protected function getTagTemplateName(string $identifier, $isInline)
     {
         if (isset($this->customTagsConfiguration[$identifier])) {
             return $this->customTagsConfiguration[$identifier]['template'];
@@ -457,11 +433,11 @@ class Renderer implements RendererInterface
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Location
      */
-    protected function checkLocation($id)
+    protected function checkLocation(int $id)
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location $location */
         $location = $this->repository->sudo(
-            static function (Repository $repository) use ($id) {
+            static function (Repository $repository) use ($id): \Ibexa\Contracts\Core\Repository\Values\Content\Location {
                 return $repository->getLocationService()->loadLocation($id);
             }
         );

--- a/src/lib/RichText/Renderer.php
+++ b/src/lib/RichText/Renderer.php
@@ -430,16 +430,14 @@ class Renderer implements RendererInterface
      *
      * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
      *
-     * @param int|string $id
-     *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Location
      */
-    protected function checkLocation(int $id)
+    protected function checkLocation(int|string $id)
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location $location */
         $location = $this->repository->sudo(
             static function (Repository $repository) use ($id): Location {
-                return $repository->getLocationService()->loadLocation($id);
+                return $repository->getLocationService()->loadLocation((int) $id);
             }
         );
 

--- a/src/lib/RichText/Renderer.php
+++ b/src/lib/RichText/Renderer.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Contracts\FieldTypeRichText\RichText\RendererInterface;
 use Psr\Log\LoggerInterface;
@@ -86,7 +87,7 @@ class Renderer implements RendererInterface
         try {
             /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content $content */
             $content = $this->repository->sudo(
-                static function (Repository $repository) use ($contentId): \Ibexa\Contracts\Core\Repository\Values\Content\Content {
+                static function (Repository $repository) use ($contentId): Content {
                     return $repository->getContentService()->loadContent((int)$contentId);
                 }
             );
@@ -437,7 +438,7 @@ class Renderer implements RendererInterface
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location $location */
         $location = $this->repository->sudo(
-            static function (Repository $repository) use ($id): \Ibexa\Contracts\Core\Repository\Values\Content\Location {
+            static function (Repository $repository) use ($id): Location {
                 return $repository->getLocationService()->loadLocation($id);
             }
         );

--- a/src/lib/RichText/Validator/CustomTagsValidator.php
+++ b/src/lib/RichText/Validator/CustomTagsValidator.php
@@ -22,10 +22,8 @@ class CustomTagsValidator implements ValidatorInterface
 {
     /**
      * Custom Tags global configuration (ibexa.richtext.custom_tags Semantic Config).
-     *
-     * @var array
      */
-    private $customTagsConfiguration;
+    private array $customTagsConfiguration;
 
     /**
      * @param array $customTagsConfiguration Injectable using "%ibexa.field_type.richtext.custom_tags%" DI Container parameter.

--- a/src/lib/RichText/Validator/InternalLinkValidator.php
+++ b/src/lib/RichText/Validator/InternalLinkValidator.php
@@ -80,6 +80,8 @@ class InternalLinkValidator implements ValidatorInterface
      */
     public function validate($scheme, $id): bool
     {
+        $id = (int) $id;
+
         try {
             switch ($scheme) {
                 case 'ezcontent':

--- a/src/lib/RichText/Validator/InternalLinkValidator.php
+++ b/src/lib/RichText/Validator/InternalLinkValidator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\FieldTypeRichText\RichText\Validator;
 
 use DOMDocument;
+use Ibexa\Contracts\Core\Persistence\Content\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Handler as ContentHandler;
 use Ibexa\Contracts\Core\Persistence\Content\Location\Handler as LocationHandler;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
@@ -20,15 +21,12 @@ use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
  */
 class InternalLinkValidator implements ValidatorInterface
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Handler
-     */
-    private $contentHandler;
+    private Handler $contentHandler;
 
     /**
      * @var \Ibexa\Contracts\Core\Persistence\Content\Location\Handler;
      */
-    private $locationHandler;
+    private LocationHandler $locationHandler;
 
     /**
      * InternalLinkValidator constructor.
@@ -89,7 +87,7 @@ class InternalLinkValidator implements ValidatorInterface
      *
      * @return bool
      */
-    public function validate($scheme, $id)
+    public function validate($scheme, $id): bool
     {
         try {
             switch ($scheme) {
@@ -122,7 +120,7 @@ class InternalLinkValidator implements ValidatorInterface
      *
      * @return string
      */
-    private function getInvalidLinkError($scheme, $url)
+    private function getInvalidLinkError(string $scheme, $url): string
     {
         switch ($scheme) {
             case 'ezcontent':
@@ -142,7 +140,7 @@ class InternalLinkValidator implements ValidatorInterface
      *
      * @return string
      */
-    private function getXPathForLinkTag($tagName)
+    private function getXPathForLinkTag(string $tagName): string
     {
         return "//docbook:{$tagName}[starts-with(@xlink:href, 'ezcontent://') or starts-with(@xlink:href, 'ezlocation://') or starts-with(@xlink:href, 'ezremote://')]";
     }

--- a/src/lib/RichText/Validator/InternalLinkValidator.php
+++ b/src/lib/RichText/Validator/InternalLinkValidator.php
@@ -80,18 +80,16 @@ class InternalLinkValidator implements ValidatorInterface
      */
     public function validate($scheme, $id): bool
     {
-        $id = (int) $id;
-
         try {
             switch ($scheme) {
                 case 'ezcontent':
-                    $this->contentHandler->loadContentInfo($id);
+                    $this->contentHandler->loadContentInfo((int) $id);
                     break;
                 case 'ezremote':
                     $this->contentHandler->loadContentInfoByRemoteId($id);
                     break;
                 case 'ezlocation':
-                    $this->locationHandler->load($id);
+                    $this->locationHandler->load((int) $id);
                     break;
                 default:
                     throw new InvalidArgumentException($scheme, "The provided scheme '{$scheme}' is not supported.");

--- a/src/lib/RichText/Validator/InternalLinkValidator.php
+++ b/src/lib/RichText/Validator/InternalLinkValidator.php
@@ -23,17 +23,8 @@ class InternalLinkValidator implements ValidatorInterface
 {
     private Handler $contentHandler;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Persistence\Content\Location\Handler;
-     */
     private LocationHandler $locationHandler;
 
-    /**
-     * InternalLinkValidator constructor.
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Content\Handler $contentHandler
-     * @param \Ibexa\Contracts\Core\Persistence\Content\Location\Handler $locationHandler
-     */
     public function __construct(ContentHandler $contentHandler, LocationHandler $locationHandler)
     {
         $this->contentHandler = $contentHandler;

--- a/src/lib/RichText/Validator/Validator.php
+++ b/src/lib/RichText/Validator/Validator.php
@@ -26,7 +26,7 @@ class Validator extends XmlBase implements ValidatorInterface
      *
      * @var string[]
      */
-    protected $schemas;
+    protected array $schemas;
 
     /**
      * @param string[] $schemas Paths to schema files to use for validation
@@ -117,7 +117,7 @@ class Validator extends XmlBase implements ValidatorInterface
      *
      * @return string[]
      */
-    protected function schematronValidate(DOMDocument $document, $filename)
+    protected function schematronValidate(DOMDocument $document, $filename): array
     {
         $stylesheet = $this->loadFile($filename);
         $xsltProcessor = new XSLTProcessor();
@@ -146,7 +146,7 @@ class Validator extends XmlBase implements ValidatorInterface
      *
      * @return string
      */
-    protected function formatSVRLFailure(DOMElement $failedAssert)
+    protected function formatSVRLFailure(DOMElement $failedAssert): string
     {
         $location = $failedAssert->getAttribute('location');
 

--- a/src/lib/RichText/Validator/ValidatorAggregate.php
+++ b/src/lib/RichText/Validator/ValidatorAggregate.php
@@ -14,7 +14,7 @@ use Ibexa\Contracts\FieldTypeRichText\RichText\ValidatorInterface;
 class ValidatorAggregate implements ValidatorInterface
 {
     /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\ValidatorInterface[] */
-    private $validators;
+    private iterable $validators;
 
     /**
      * @param iterable $validators

--- a/src/lib/RichText/Validator/ValidatorDispatcher.php
+++ b/src/lib/RichText/Validator/ValidatorDispatcher.php
@@ -40,7 +40,7 @@ class ValidatorDispatcher implements ValidatorInterface
      * @param string $namespace
      * @param \Ibexa\FieldTypeRichText\eZ\RichText\Validator $validator
      */
-    public function addValidator($namespace, ValidatorInterface $validator = null)
+    public function addValidator($namespace, ValidatorInterface $validator = null): void
     {
         $this->mapping[$namespace] = $validator;
     }

--- a/src/lib/Translation/Extractor/OnlineEditorCustomAttributesExtractor.php
+++ b/src/lib/Translation/Extractor/OnlineEditorCustomAttributesExtractor.php
@@ -20,15 +20,12 @@ final class OnlineEditorCustomAttributesExtractor implements ExtractorInterface
     private const ATTRIBUTES_MESSAGE_ID_PREFIX = 'ezrichtext.attributes';
     private const CLASS_LABEL_MESSAGE_ID = 'ezrichtext.classes.class.label';
 
-    /**
-     * @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     /**
      * @var string[]
      */
-    private $siteAccessList;
+    private array $siteAccessList;
 
     /**
      * @param \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface $configResolver

--- a/src/lib/Validator/Constraints/RichTextValidator.php
+++ b/src/lib/Validator/Constraints/RichTextValidator.php
@@ -16,10 +16,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 class RichTextValidator extends ConstraintValidator
 {
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\InputHandlerInterface
-     */
-    private $inputHandler;
+    private InputHandlerInterface $inputHandler;
 
     /**
      * @param \Ibexa\Contracts\FieldTypeRichText\RichText\InputHandlerInterface

--- a/tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
@@ -29,7 +29,7 @@ class RichTextHtml5ConverterPassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new RichTextHtml5ConverterPass());
     }
 
-    public function testCollectProviders()
+    public function testCollectProviders(): void
     {
         $configurationResolver = new Definition();
         $this->setDefinition(

--- a/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -266,6 +266,9 @@ class RichTextTest extends AbstractParserTestCase
         }
     }
 
+    /**
+     * @phpstan-return list<array{array<string, mixed>, array<string, mixed>}>
+     */
     public function richTextSettingsProvider(): array
     {
         return [

--- a/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -22,10 +22,8 @@ class RichTextTest extends AbstractParserTestCase
 {
     /**
      * Multidimensional array of configuration of multiple extensions ([extension => config]).
-     *
-     * @var array
      */
-    private $extensionsConfig;
+    private ?array $extensionsConfig = null;
 
     /**
      * Get test configuration for multiple extensions.
@@ -94,7 +92,7 @@ class RichTextTest extends AbstractParserTestCase
         return $this->getExtensionsConfig();
     }
 
-    public function testDefaultContentSettings()
+    public function testDefaultContentSettings(): void
     {
         $this->configureAndLoad();
 
@@ -120,7 +118,7 @@ class RichTextTest extends AbstractParserTestCase
     /**
      * Test Rich Text Custom Tags invalid settings, like enabling undefined Custom Tag.
      */
-    public function testRichTextCustomTagsInvalidSettings()
+    public function testRichTextCustomTagsInvalidSettings(): void
     {
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Unknown RichText Custom Tag \'foo\'');
@@ -251,7 +249,7 @@ class RichTextTest extends AbstractParserTestCase
      *
      * @throws \Exception
      */
-    public function testRichTextSettings(array $config, array $expected)
+    public function testRichTextSettings(array $config, array $expected): void
     {
         $this->configureAndLoad(
             [
@@ -268,7 +266,7 @@ class RichTextTest extends AbstractParserTestCase
         }
     }
 
-    public function richTextSettingsProvider()
+    public function richTextSettingsProvider(): array
     {
         return [
             [

--- a/tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
@@ -35,17 +35,11 @@ class RichTextFieldTypeIntegrationTest extends SearchBaseIntegrationTest
 {
     use RelationSearchBaseIntegrationTestTrait;
 
-    /**
-     * @var \DOMDocument
-     */
-    private $createdDOMValue;
+    private DOMDocument $createdDOMValue;
 
-    /**
-     * @var \DOMDocument
-     */
-    private $updatedDOMValue;
+    private DOMDocument $updatedDOMValue;
 
-    public function __construct($name = null, array $data = [], $dataName = '')
+    public function __construct(?string $name = null, array $data = [], $dataName = '')
     {
         $this->createdDOMValue = new DOMDocument();
         $this->createdDOMValue->loadXML(
@@ -251,7 +245,7 @@ EOT
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Field $field
      */
-    public function assertFieldDataLoadedCorrect(Field $field)
+    public function assertFieldDataLoadedCorrect(Field $field): void
     {
         self::assertInstanceOf(
             RichTextValue::class,
@@ -314,7 +308,7 @@ EOT
      *
      * @return array
      */
-    public function assertUpdatedFieldDataLoadedCorrect(Field $field)
+    public function assertUpdatedFieldDataLoadedCorrect(Field $field): void
     {
         self::assertInstanceOf(
             RichTextValue::class,
@@ -363,7 +357,7 @@ EOT
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Field $field
      */
-    public function assertCopiedFieldDataLoadedCorrectly(Field $field)
+    public function assertCopiedFieldDataLoadedCorrectly(Field $field): void
     {
         self::assertInstanceOf(
             RichTextValue::class,
@@ -451,7 +445,7 @@ EOT
      * @todo: Requires correct registered FieldTypeService, needs to be
      *        maintained!
      */
-    public function testFromHash($hash, $expectedValue = null)
+    public function testFromHash($hash, $expectedValue = null): void
     {
         $richTextValue = $this
             ->getRepository()
@@ -509,7 +503,7 @@ EOT;
      *
      * @see testConvertReomoteObjectIdToObjectId()
      */
-    public function providerForTestConvertRemoteObjectIdToObjectId()
+    public function providerForTestConvertRemoteObjectIdToObjectId(): array
     {
         $remoteId = '[RemoteId]';
         $objectId = '[ObjectId]';
@@ -790,7 +784,7 @@ EOT;
      *
      * @dataProvider providerForTestCreateContentWithValidCustomTag
      */
-    public function testCreateContentWithValidCustomTag($xmlDocumentPath)
+    public function testCreateContentWithValidCustomTag($xmlDocumentPath): void
     {
         $validXmlDocument = $this->createDocument($xmlDocumentPath);
         $this->createContent(new RichTextValue($validXmlDocument));
@@ -801,7 +795,7 @@ EOT;
      *
      * @return array
      */
-    public function providerForTestCreateContentWithValidCustomTag()
+    public function providerForTestCreateContentWithValidCustomTag(): array
     {
         $data = [];
         $iterator = new DirectoryIterator(__DIR__ . '/_fixtures/ezrichtext/custom_tags/valid');
@@ -824,8 +818,8 @@ EOT;
      */
     public function testCreateContentWithInvalidCustomTag(
         $xmlDocumentPath,
-        $expectedValidationMessage
-    ) {
+        string $expectedValidationMessage
+    ): void {
         try {
             $invalidXmlDocument = $this->createDocument($xmlDocumentPath);
             $this->createContent(new RichTextValue($invalidXmlDocument));
@@ -843,7 +837,7 @@ EOT;
      *
      * @return array
      */
-    public function providerForTestCreateContentWithInvalidCustomTag()
+    public function providerForTestCreateContentWithInvalidCustomTag(): array
     {
         $data = [
             [
@@ -868,7 +862,7 @@ EOT;
      *
      * @return \DOMDocument
      */
-    protected function createDocument($filename)
+    protected function createDocument($filename): DOMDocument
     {
         $document = new DOMDocument();
 
@@ -890,7 +884,7 @@ EOT;
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ForbiddenException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      */
-    private function prepareInternalLinkValidatorBrokenLinksTestCase(Repository $repository)
+    private function prepareInternalLinkValidatorBrokenLinksTestCase(Repository $repository): array
     {
         $contentService = $repository->getContentService();
         $locationService = $repository->getLocationService();
@@ -939,7 +933,7 @@ EOT;
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      */
-    public function testInternalLinkValidatorIgnoresMissingRelationOnNotUpdatedField()
+    public function testInternalLinkValidatorIgnoresMissingRelationOnNotUpdatedField(): void
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -967,7 +961,7 @@ EOT;
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
      */
-    public function testInternalLinkValidatorReturnsErrorOnMissingRelationInUpdatedField()
+    public function testInternalLinkValidatorReturnsErrorOnMissingRelationInUpdatedField(): void
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -1054,7 +1048,7 @@ XML
      *
      * @return \DOMDocument
      */
-    private function getDocumentWithLocationLink(Location $location)
+    private function getDocumentWithLocationLink(Location $location): DOMDocument
     {
         $document = new DOMDocument();
         $document->loadXML(

--- a/tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/Repository/RichTextFieldTypeIntegrationTest.php
@@ -293,20 +293,14 @@ EOT
 
     /**
      * Get update field externals data.
-     *
-     * @return array
      */
-    public function getValidUpdateFieldData()
+    public function getValidUpdateFieldData(): RichTextValue
     {
         return new RichTextValue($this->updatedDOMValue);
     }
 
     /**
      * Get externals updated field data values.
-     *
-     * This is a PHPUnit data provider
-     *
-     * @return array
      */
     public function assertUpdatedFieldDataLoadedCorrect(Field $field): void
     {
@@ -502,6 +496,8 @@ EOT;
      * This is a PHP Unit data provider
      *
      * @see testConvertReomoteObjectIdToObjectId()
+     *
+     * @phpstan-return list<array{string, string}>
      */
     public function providerForTestConvertRemoteObjectIdToObjectId(): array
     {

--- a/tests/lib/Configuration/AggregateProviderTest.php
+++ b/tests/lib/Configuration/AggregateProviderTest.php
@@ -22,7 +22,7 @@ class AggregateProviderTest extends TestCase
      *
      * @dataProvider getConfiguration
      *
-     * @param array $configuration
+     * @param array<string, array<string, mixed>> $configuration
      */
     public function testGetConfiguration(array $configuration): void
     {
@@ -31,8 +31,12 @@ class AggregateProviderTest extends TestCase
             $providers[] = new class($providerName, $providerConfiguration) implements Provider {
                 private string $name;
 
+                /** @var array<string, mixed> */
                 private array $configuration;
 
+                /**
+                 * @param array<string, mixed> $configuration
+                 */
                 public function __construct(string $name, array $configuration)
                 {
                     $this->name = $name;
@@ -44,6 +48,9 @@ class AggregateProviderTest extends TestCase
                     return $this->name;
                 }
 
+                /**
+                 * @return array<string, mixed>
+                 */
                 public function getConfiguration(): array
                 {
                     return $this->configuration;

--- a/tests/lib/Configuration/AggregateProviderTest.php
+++ b/tests/lib/Configuration/AggregateProviderTest.php
@@ -29,9 +29,9 @@ class AggregateProviderTest extends TestCase
         $providers = [];
         foreach ($configuration as $providerName => $providerConfiguration) {
             $providers[] = new class($providerName, $providerConfiguration) implements Provider {
-                private $name;
+                private string $name;
 
-                private $configuration;
+                private array $configuration;
 
                 public function __construct(string $name, array $configuration)
                 {

--- a/tests/lib/Configuration/Provider/AlloyEditorTest.php
+++ b/tests/lib/Configuration/Provider/AlloyEditorTest.php
@@ -13,11 +13,12 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Contracts\FieldTypeRichText\Configuration\Provider;
 use Ibexa\FieldTypeRichText\Configuration\Provider\AlloyEditor;
 use Ibexa\FieldTypeRichText\Configuration\UI\Mapper\OnlineEditorConfigMapper;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class AlloyEditorTest extends BaseProviderTestCase
 {
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\FieldTypeRichText\Configuration\UI\Mapper\OnlineEditorConfigMapper */
-    private $mapper;
+    private MockObject $mapper;
 
     public function setUp(): void
     {

--- a/tests/lib/Configuration/Provider/AlloyEditorTest.php
+++ b/tests/lib/Configuration/Provider/AlloyEditorTest.php
@@ -17,8 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class AlloyEditorTest extends BaseProviderTestCase
 {
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\FieldTypeRichText\Configuration\UI\Mapper\OnlineEditorConfigMapper */
-    private MockObject $mapper;
+    private OnlineEditorConfigMapper&MockObject $mapper;
 
     public function setUp(): void
     {

--- a/tests/lib/Configuration/Provider/BaseCustomTemplateProviderTestCase.php
+++ b/tests/lib/Configuration/Provider/BaseCustomTemplateProviderTestCase.php
@@ -9,11 +9,12 @@ declare(strict_types=1);
 namespace Ibexa\Tests\FieldTypeRichText\Configuration\Provider;
 
 use Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomTemplateConfigMapper;
+use PHPUnit\Framework\MockObject\MockObject;
 
 abstract class BaseCustomTemplateProviderTestCase extends BaseProviderTestCase
 {
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomStyle */
-    protected $mapper;
+    protected MockObject $mapper;
 
     abstract protected function getExpectedCustomTemplatesConfiguration(): array;
 
@@ -29,7 +30,7 @@ abstract class BaseCustomTemplateProviderTestCase extends BaseProviderTestCase
     /**
      * @covers \Ibexa\Contracts\FieldTypeRichText\Configuration\Provider::getConfiguration
      */
-    final public function testGetConfiguration()
+    final public function testGetConfiguration(): void
     {
         $provider = $this->createProvider();
 

--- a/tests/lib/Configuration/Provider/BaseCustomTemplateProviderTestCase.php
+++ b/tests/lib/Configuration/Provider/BaseCustomTemplateProviderTestCase.php
@@ -13,8 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 abstract class BaseCustomTemplateProviderTestCase extends BaseProviderTestCase
 {
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\FieldTypeRichText\Configuration\UI\Mapper\CustomStyle */
-    protected MockObject $mapper;
+    protected CustomTemplateConfigMapper&MockObject $mapper;
 
     abstract protected function getExpectedCustomTemplatesConfiguration(): array;
 

--- a/tests/lib/Configuration/Provider/BaseProviderTestCase.php
+++ b/tests/lib/Configuration/Provider/BaseProviderTestCase.php
@@ -15,8 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class BaseProviderTestCase extends TestCase
 {
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    protected MockObject $configResolver;
+    protected ConfigResolverInterface&MockObject $configResolver;
 
     public function setUp(): void
     {

--- a/tests/lib/Configuration/Provider/BaseProviderTestCase.php
+++ b/tests/lib/Configuration/Provider/BaseProviderTestCase.php
@@ -10,12 +10,13 @@ namespace Ibexa\Tests\FieldTypeRichText\Configuration\Provider;
 
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Contracts\FieldTypeRichText\Configuration\Provider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 abstract class BaseProviderTestCase extends TestCase
 {
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    protected $configResolver;
+    protected MockObject $configResolver;
 
     public function setUp(): void
     {

--- a/tests/lib/Configuration/UI/Config/Mapper/CustomTagTest.php
+++ b/tests/lib/Configuration/UI/Config/Mapper/CustomTagTest.php
@@ -37,7 +37,7 @@ class CustomTagTest extends TestCase
         array $customTagsConfiguration,
         array $enabledCustomTags,
         array $expectedConfig
-    ) {
+    ): void {
         $mapper = new CustomTag(
             $customTagsConfiguration,
             $this->getTranslatorInterfaceMock(),

--- a/tests/lib/Configuration/UI/Config/Mapper/OnlineEditorTest.php
+++ b/tests/lib/Configuration/UI/Config/Mapper/OnlineEditorTest.php
@@ -15,7 +15,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class OnlineEditorTest extends TestCase
 {
     /** @var \Ibexa\FieldTypeRichText\Configuration\UI\Mapper\OnlineEditorConfigMapper */
-    private $mapper;
+    private OnlineEditor $mapper;
 
     public function setUp(): void
     {

--- a/tests/lib/Configuration/UI/Config/Mapper/OnlineEditorTest.php
+++ b/tests/lib/Configuration/UI/Config/Mapper/OnlineEditorTest.php
@@ -14,12 +14,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class OnlineEditorTest extends TestCase
 {
-    /** @var \Ibexa\FieldTypeRichText\Configuration\UI\Mapper\OnlineEditorConfigMapper */
     private OnlineEditor $mapper;
 
     public function setUp(): void
     {
-        /** @var \Symfony\Contracts\Translation\TranslatorInterface $translatorMock */
         $translatorMock = $this->createMock(TranslatorInterface::class);
         $translatorMock
             ->expects(self::any())

--- a/tests/lib/FieldType/RichText/Gateway/DoctrineStorageTest.php
+++ b/tests/lib/FieldType/RichText/Gateway/DoctrineStorageTest.php
@@ -22,7 +22,7 @@ class DoctrineStorageTest extends TestCase
      */
     protected $storageGateway;
 
-    public function testGetContentIds()
+    public function testGetContentIds(): void
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentobjects.php');
 

--- a/tests/lib/FieldType/RichText/RichTextStorageTest.php
+++ b/tests/lib/FieldType/RichText/RichTextStorageTest.php
@@ -14,12 +14,13 @@ use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class RichTextStorageTest extends TestCase
 {
-    public function providerForTestGetFieldData()
+    public function providerForTestGetFieldData(): array
     {
         return [
             [
@@ -64,7 +65,7 @@ class RichTextStorageTest extends TestCase
     /**
      * @dataProvider providerForTestGetFieldData
      */
-    public function testGetFieldData($xmlString, $updatedXmlString, $linkIds, $linkUrls): void
+    public function testGetFieldData(string $xmlString, string $updatedXmlString, array $linkIds, array $linkUrls): void
     {
         $gateway = $this->getGatewayMock();
         $gateway
@@ -79,7 +80,7 @@ class RichTextStorageTest extends TestCase
 
         $logger = $this->getLoggerMock();
         $missingIds = array_diff($linkIds, array_keys($linkUrls));
-        $errorMessages = array_map(static function (int $missingId) {
+        $errorMessages = array_map(static function (int $missingId): string {
             return "URL with ID {$missingId} not found";
         }, $missingIds);
 
@@ -104,7 +105,7 @@ class RichTextStorageTest extends TestCase
         );
     }
 
-    public function providerForTestStoreFieldData()
+    public function providerForTestStoreFieldData(): array
     {
         return [
             [
@@ -176,14 +177,14 @@ class RichTextStorageTest extends TestCase
      * @dataProvider providerForTestStoreFieldData
      */
     public function testStoreFieldData(
-        $xmlString,
-        $updatedXmlString,
-        $linkUrls,
-        $linkIds,
-        $insertLinks,
-        $remoteIds,
-        $contentIds,
-        $isUpdated
+        string $xmlString,
+        string $updatedXmlString,
+        array $linkUrls,
+        array $linkIds,
+        array $insertLinks,
+        array $remoteIds,
+        array $contentIds,
+        bool $isUpdated
     ): void {
         $versionInfo = new VersionInfo(['versionNo' => 24]);
         $value = new FieldValue(['data' => $xmlString]);
@@ -220,7 +221,7 @@ class RichTextStorageTest extends TestCase
             ->withConsecutive($urlAssertions)
             ->willReturnOnConsecutiveCalls(...$insertedIds);
 
-        $linkUrlsArguments = array_map(static function (int $id) {
+        $linkUrlsArguments = array_map(static function (int $id): array {
             return [$id, 42, 24];
         }, $idsToLink);
 
@@ -303,12 +304,12 @@ class RichTextStorageTest extends TestCase
      * @dataProvider providerForTestStoreFieldDataThrowsNotFoundException
      */
     public function testStoreFieldDataThrowsNotFoundException(
-        $xmlString,
-        $linkUrls,
-        $linkIds,
-        $insertLinks,
-        $remoteIds,
-        $contentIds
+        string $xmlString,
+        array $linkUrls,
+        array $linkIds,
+        array $insertLinks,
+        array $remoteIds,
+        array $contentIds
     ): void {
         $this->expectException(NotFoundException::class);
 
@@ -372,7 +373,7 @@ class RichTextStorageTest extends TestCase
      *
      * @return \Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getPartlyMockedStorage(StorageGateway $gateway)
+    protected function getPartlyMockedStorage(StorageGateway $gateway): MockObject
     {
         return $this->getMockBuilder(RichTextStorage::class)
             ->setConstructorArgs(
@@ -388,7 +389,7 @@ class RichTextStorageTest extends TestCase
     /**
      * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $loggerMock;
+    protected ?MockObject $loggerMock = null;
 
     /**
      * @return \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
@@ -407,7 +408,7 @@ class RichTextStorageTest extends TestCase
     /**
      * @var \Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage\Gateway|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $gatewayMock;
+    protected ?MockObject $gatewayMock = null;
 
     /**
      * @return \Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage\Gateway|\PHPUnit\Framework\MockObject\MockObject

--- a/tests/lib/FieldType/RichText/RichTextStorageTest.php
+++ b/tests/lib/FieldType/RichText/RichTextStorageTest.php
@@ -14,12 +14,16 @@ use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage;
+use Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage\Gateway;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class RichTextStorageTest extends TestCase
 {
+    /**
+     * @phpstan-return list<array{string, string, int[], array<int, string>}>
+     */
     public function providerForTestGetFieldData(): array
     {
         return [
@@ -64,6 +68,9 @@ class RichTextStorageTest extends TestCase
 
     /**
      * @dataProvider providerForTestGetFieldData
+     *
+     * @param int[] $linkIds
+     * @param array<int, string> $linkUrls
      */
     public function testGetFieldData(string $xmlString, string $updatedXmlString, array $linkIds, array $linkUrls): void
     {
@@ -105,6 +112,9 @@ class RichTextStorageTest extends TestCase
         );
     }
 
+    /**
+     * @return list<array{string, string, string[], array<string, int>, array<string, int>, string[], array<string, int>, bool}>
+     */
     public function providerForTestStoreFieldData(): array
     {
         return [
@@ -175,6 +185,12 @@ class RichTextStorageTest extends TestCase
 
     /**
      * @dataProvider providerForTestStoreFieldData
+     *
+     * @param string[] $linkUrls
+     * @param array<string, int> $linkIds
+     * @param array<string, int> $insertLinks
+     * @param string[] $remoteIds
+     * @param array<string, int> $contentIds
      */
     public function testStoreFieldData(
         string $xmlString,
@@ -280,6 +296,9 @@ class RichTextStorageTest extends TestCase
         ];
     }
 
+    /**
+     * @return list<array{string, string[], array<string, int>, array<int, array{url: string, id: int}>, string[], array<string, int>}>
+     */
     public function providerForTestStoreFieldDataThrowsNotFoundException(): array
     {
         return [
@@ -302,6 +321,12 @@ class RichTextStorageTest extends TestCase
 
     /**
      * @dataProvider providerForTestStoreFieldDataThrowsNotFoundException
+     *
+     * @param string[] $linkUrls
+     * @param array<string, int> $linkIds
+     * @param array<int, array{url: string, id: int}> $insertLinks
+     * @param string[] $remoteIds
+     * @param array<string, int> $contentIds
      */
     public function testStoreFieldDataThrowsNotFoundException(
         string $xmlString,
@@ -368,12 +393,7 @@ class RichTextStorageTest extends TestCase
         );
     }
 
-    /**
-     * @param \Ibexa\Contracts\Core\FieldType\StorageGateway $gateway
-     *
-     * @return \Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getPartlyMockedStorage(StorageGateway $gateway): MockObject
+    protected function getPartlyMockedStorage(StorageGateway $gateway): RichTextStorage
     {
         return $this->getMockBuilder(RichTextStorage::class)
             ->setConstructorArgs(
@@ -386,15 +406,9 @@ class RichTextStorageTest extends TestCase
             ->getMock();
     }
 
-    /**
-     * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected ?MockObject $loggerMock = null;
+    protected (LoggerInterface&MockObject)|null $loggerMock = null;
 
-    /**
-     * @return \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getLoggerMock()
+    protected function getLoggerMock(): LoggerInterface&MockObject
     {
         if (!isset($this->loggerMock)) {
             $this->loggerMock = $this->getMockForAbstractClass(
@@ -405,18 +419,12 @@ class RichTextStorageTest extends TestCase
         return $this->loggerMock;
     }
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage\Gateway|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected ?MockObject $gatewayMock = null;
+    protected (Gateway&MockObject)|null $gatewayMock = null;
 
-    /**
-     * @return \Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage\Gateway|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getGatewayMock()
+    protected function getGatewayMock(): Gateway&MockObject
     {
         if (!isset($this->gatewayMock)) {
-            $this->gatewayMock = $this->createMock(RichTextStorage\Gateway::class);
+            $this->gatewayMock = $this->createMock(Gateway::class);
         }
 
         return $this->gatewayMock;

--- a/tests/lib/FieldType/RichText/SearchFieldTest.php
+++ b/tests/lib/FieldType/RichText/SearchFieldTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 final class SearchFieldTest extends TestCase
 {
     /** @var \Ibexa\FieldTypeRichText\FieldType\RichText\SearchField */
-    private $searchField;
+    private SearchField $searchField;
 
     /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\TextExtractorInterface&\PHPUnit\Framework\MockObject\MockObject */
     private TextExtractorInterface $shortTextExtractor;

--- a/tests/lib/FieldType/RichText/SearchFieldTest.php
+++ b/tests/lib/FieldType/RichText/SearchFieldTest.php
@@ -14,19 +14,20 @@ use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
 use Ibexa\Contracts\Core\Search;
 use Ibexa\Contracts\FieldTypeRichText\RichText\TextExtractorInterface;
 use Ibexa\FieldTypeRichText\FieldType\RichText\SearchField;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class SearchFieldTest extends TestCase
 {
-    /** @var \Ibexa\FieldTypeRichText\FieldType\RichText\SearchField */
     private SearchField $searchField;
 
-    /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\TextExtractorInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private TextExtractorInterface $shortTextExtractor;
+    private TextExtractorInterface&MockObject $shortTextExtractor;
 
-    /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\TextExtractorInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private TextExtractorInterface $fullTextExtractor;
+    private TextExtractorInterface&MockObject $fullTextExtractor;
 
+    /**
+     * @return array<string, array{string, \Ibexa\Contracts\Core\Search\Field[], string[]}>
+     */
     public function getDataForTestGetIndexData(): array
     {
         $simpleStubShortTextValue = 'Welcome to Ibexa';

--- a/tests/lib/FieldType/RichTextTest.php
+++ b/tests/lib/FieldType/RichTextTest.php
@@ -118,6 +118,9 @@ class RichTextTest extends TestCase
         $this->getFieldType()->acceptValue($this->createMock(CoreValue::class));
     }
 
+    /**
+     * @phpstan-return list<array{string}>
+     */
     public static function providerForTestAcceptValueValidFormat(): array
     {
         return [
@@ -149,6 +152,9 @@ class RichTextTest extends TestCase
         $fieldType->acceptValue($input);
     }
 
+    /**
+     * @phpstan-return list<array{string, \Exception}>
+     */
     public static function providerForTestAcceptValueInvalidFormat(): array
     {
         return [
@@ -191,6 +197,9 @@ class RichTextTest extends TestCase
         }
     }
 
+    /**
+     * @phpstan-return list<array{string, \Ibexa\Contracts\Core\FieldType\ValidationError[]}>
+     */
     public function providerForTestValidate(): array
     {
         return [
@@ -344,6 +353,8 @@ class RichTextTest extends TestCase
     /**
      * @todo format does not really matter for the method tested, but the fixtures here should be replaced
      * by valid docbook anyway
+     *
+     * @phpstan-return list<array{string, string}>
      */
     public static function providerForTestGetName(): array
     {
@@ -484,10 +495,5 @@ EOT;
     protected function provideFieldTypeIdentifier(): string
     {
         return 'ezrichtext';
-    }
-
-    public function provideDataForGetName(): array
-    {
-        return [];
     }
 }

--- a/tests/lib/FieldType/RichTextTest.php
+++ b/tests/lib/FieldType/RichTextTest.php
@@ -18,6 +18,7 @@ use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Value as CoreValue;
 use Ibexa\Core\Persistence\TransformationProcessor;
+use Ibexa\FieldTypeRichText\FieldType\RichText\Type;
 use Ibexa\FieldTypeRichText\FieldType\RichText\Type as RichTextType;
 use Ibexa\FieldTypeRichText\FieldType\RichText\Value;
 use Ibexa\FieldTypeRichText\RichText\ConverterDispatcher;
@@ -28,6 +29,7 @@ use Ibexa\FieldTypeRichText\RichText\RelationProcessor;
 use Ibexa\FieldTypeRichText\RichText\Validator\Validator;
 use Ibexa\FieldTypeRichText\RichText\Validator\ValidatorDispatcher;
 use Ibexa\FieldTypeRichText\RichText\XMLSanitizer;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -40,7 +42,7 @@ class RichTextTest extends TestCase
     /**
      * @return \Ibexa\FieldTypeRichText\FieldType\RichText\Type
      */
-    protected function getFieldType()
+    protected function getFieldType(): Type
     {
         $inputHandler = new InputHandler(
             new DOMDocumentFactory(new XMLSanitizer()),
@@ -69,7 +71,7 @@ class RichTextTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getTransformationProcessorMock()
+    protected function getTransformationProcessorMock(): MockObject
     {
         return $this->getMockForAbstractClass(
             TransformationProcessor::class,
@@ -84,7 +86,7 @@ class RichTextTest extends TestCase
     /**
      * @covers \Ibexa\Core\FieldType\FieldType::getValidatorConfigurationSchema
      */
-    public function testValidatorConfigurationSchema()
+    public function testValidatorConfigurationSchema(): void
     {
         $fieldType = $this->getFieldType();
         self::assertEmpty(
@@ -96,7 +98,7 @@ class RichTextTest extends TestCase
     /**
      * @covers \Ibexa\Core\FieldType\FieldType::getSettingsSchema
      */
-    public function testSettingsSchema()
+    public function testSettingsSchema(): void
     {
         $fieldType = $this->getFieldType();
         self::assertSame(
@@ -109,14 +111,14 @@ class RichTextTest extends TestCase
     /**
      * @covers \Ibexa\FieldTypeRichText\FieldType\RichText\Type::acceptValue
      */
-    public function testAcceptValueInvalidType()
+    public function testAcceptValueInvalidType(): void
     {
         $this->expectException(ApiInvalidArgumentException::class);
 
         $this->getFieldType()->acceptValue($this->createMock(CoreValue::class));
     }
 
-    public static function providerForTestAcceptValueValidFormat()
+    public static function providerForTestAcceptValueValidFormat(): array
     {
         return [
             [
@@ -141,13 +143,13 @@ class RichTextTest extends TestCase
      *
      * @dataProvider providerForTestAcceptValueValidFormat
      */
-    public function testAcceptValueValidFormat($input)
+    public function testAcceptValueValidFormat(string $input): void
     {
         $fieldType = $this->getFieldType();
         $fieldType->acceptValue($input);
     }
 
-    public static function providerForTestAcceptValueInvalidFormat()
+    public static function providerForTestAcceptValueInvalidFormat(): array
     {
         return [
             [
@@ -172,7 +174,7 @@ class RichTextTest extends TestCase
      *
      * @dataProvider providerForTestAcceptValueInvalidFormat
      */
-    public function testAcceptValueInvalidFormat($input, Exception $expectedException)
+    public function testAcceptValueInvalidFormat(string $input, Exception $expectedException): void
     {
         try {
             $fieldType = $this->getFieldType();
@@ -189,7 +191,7 @@ class RichTextTest extends TestCase
         }
     }
 
-    public function providerForTestValidate()
+    public function providerForTestValidate(): array
     {
         return [
             [
@@ -291,7 +293,7 @@ class RichTextTest extends TestCase
      * @param string $xmlString
      * @param array $expectedValidationErrors
      */
-    public function testValidate($xmlString, array $expectedValidationErrors)
+    public function testValidate(string $xmlString, array $expectedValidationErrors): void
     {
         $fieldType = $this->getFieldType();
         $value = new Value($xmlString);
@@ -307,7 +309,7 @@ class RichTextTest extends TestCase
     /**
      * @covers \Ibexa\FieldTypeRichText\FieldType\RichText\Type::toPersistenceValue
      */
-    public function testToPersistenceValue()
+    public function testToPersistenceValue(): void
     {
         $xmlString = '<?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0">
@@ -328,7 +330,7 @@ class RichTextTest extends TestCase
      *
      * @dataProvider providerForTestGetName
      */
-    public function testGetName($xmlString, $expectedName)
+    public function testGetName(string $xmlString, string $expectedName): void
     {
         $value = new Value($xmlString);
 
@@ -343,7 +345,7 @@ class RichTextTest extends TestCase
      * @todo format does not really matter for the method tested, but the fixtures here should be replaced
      * by valid docbook anyway
      */
-    public static function providerForTestGetName()
+    public static function providerForTestGetName(): array
     {
         return [
             [
@@ -433,7 +435,7 @@ class RichTextTest extends TestCase
      *
      * @covers \Ibexa\FieldTypeRichText\FieldType\RichText\Type::getRelations
      */
-    public function testGetRelations()
+    public function testGetRelations(): void
     {
         $xml = <<<EOT
 <?xml version="1.0" encoding="UTF-8"?>
@@ -469,7 +471,7 @@ EOT;
      *
      * @return string
      */
-    protected function getAbsolutePath($relativePath)
+    protected function getAbsolutePath(string $relativePath): string
     {
         $absolutePath = realpath(__DIR__ . '/../../../' . $relativePath);
         if (false === $absolutePath) {
@@ -479,12 +481,12 @@ EOT;
         return $absolutePath;
     }
 
-    protected function provideFieldTypeIdentifier()
+    protected function provideFieldTypeIdentifier(): string
     {
         return 'ezrichtext';
     }
 
-    public function provideDataForGetName()
+    public function provideDataForGetName(): array
     {
         return [];
     }

--- a/tests/lib/FieldType/RichTextTest.php
+++ b/tests/lib/FieldType/RichTextTest.php
@@ -68,10 +68,7 @@ class RichTextTest extends TestCase
         return $fieldType;
     }
 
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getTransformationProcessorMock(): MockObject
+    protected function getTransformationProcessorMock(): TransformationProcessor&MockObject
     {
         return $this->getMockForAbstractClass(
             TransformationProcessor::class,

--- a/tests/lib/Form/DataTransformer/RichTextTransformerTest.php
+++ b/tests/lib/Form/DataTransformer/RichTextTransformerTest.php
@@ -23,13 +23,10 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 
 class RichTextTransformerTest extends TestCase
 {
-    /** @var \Ibexa\FieldTypeRichText\RichText\InputHandlerInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $inputHandler;
+    private InputHandlerInterface&MockObject $inputHandler;
 
-    /** @var \Ibexa\FieldTypeRichText\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $docbook2xhtml5editConverter;
+    private Converter&MockObject $docbook2xhtml5editConverter;
 
-    /** @var \Ibexa\FieldTypeRichText\Form\DataTransformer\RichTextTransformer */
     private RichTextTransformer $richTextTransformer;
 
     protected function setUp(): void

--- a/tests/lib/Form/DataTransformer/RichTextTransformerTest.php
+++ b/tests/lib/Form/DataTransformer/RichTextTransformerTest.php
@@ -130,6 +130,9 @@ class RichTextTransformerTest extends TestCase
         $this->richTextTransformer->reverseTransform($value);
     }
 
+    /**
+     * @phpstan-return list<array{\Exception}>
+     */
     public function dataProviderForReverseTransformTransformationFailedException(): array
     {
         return [

--- a/tests/lib/Form/DataTransformer/RichTextTransformerTest.php
+++ b/tests/lib/Form/DataTransformer/RichTextTransformerTest.php
@@ -17,19 +17,20 @@ use Ibexa\Contracts\FieldTypeRichText\RichText\InputHandlerInterface;
 use Ibexa\FieldTypeRichText\Form\DataTransformer\RichTextTransformer;
 use Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory;
 use Ibexa\FieldTypeRichText\RichText\XMLSanitizer;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
 class RichTextTransformerTest extends TestCase
 {
     /** @var \Ibexa\FieldTypeRichText\RichText\InputHandlerInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $inputHandler;
+    private MockObject $inputHandler;
 
     /** @var \Ibexa\FieldTypeRichText\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject */
-    private $docbook2xhtml5editConverter;
+    private MockObject $docbook2xhtml5editConverter;
 
     /** @var \Ibexa\FieldTypeRichText\Form\DataTransformer\RichTextTransformer */
-    private $richTextTransformer;
+    private RichTextTransformer $richTextTransformer;
 
     protected function setUp(): void
     {
@@ -62,7 +63,7 @@ class RichTextTransformerTest extends TestCase
         $this->docbook2xhtml5editConverter
             ->expects(self::once())
             ->method('convert')
-            ->willReturnCallback(function (DOMDocument $doc) use ($inputXML, $outputDocument) {
+            ->willReturnCallback(function (DOMDocument $doc) use ($inputXML, $outputDocument): \DOMDocument {
                 $this->assertXmlStringEqualsXmlString($inputXML, $doc->saveXML());
 
                 return $outputDocument;
@@ -132,7 +133,7 @@ class RichTextTransformerTest extends TestCase
         $this->richTextTransformer->reverseTransform($value);
     }
 
-    public function dataProviderForReverseTransformTransformationFailedException()
+    public function dataProviderForReverseTransformTransformationFailedException(): array
     {
         return [
             [$this->createMock(NotFoundException::class)],

--- a/tests/lib/Persistence/Legacy/Tests/Content/FieldValue/Converter/RichTextFieldValueConverterTest.php
+++ b/tests/lib/Persistence/Legacy/Tests/Content/FieldValue/Converter/RichTextFieldValueConverterTest.php
@@ -29,7 +29,7 @@ class RichTextFieldValueConverterTest extends TestCase
     /**
      * @var string
      */
-    private $docbookString;
+    private string $docbookString;
 
     protected function setUp(): void
     {

--- a/tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php
+++ b/tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php
@@ -16,6 +16,13 @@ use PHPUnit\Framework\TestCase;
 
 class RichTextProcessorTest extends TestCase
 {
+    protected Converter&MockObject $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = $this->createMock(Converter::class);
+    }
+
     public function testPostProcessValueHash(): void
     {
         $processor = $this->getProcessor();
@@ -54,18 +61,8 @@ EOT;
         );
     }
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected ?MockObject $converter = null;
-
-    /**
-     * @return \Ibexa\FieldTypeRichText\REST\FieldTypeProcessor\RichTextProcessor
-     */
     protected function getProcessor(): RichTextProcessor
     {
-        $this->converter = $this->createMock(Converter::class);
-
         return new RichTextProcessor($this->converter);
     }
 }

--- a/tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php
+++ b/tests/lib/REST/FieldTypeProcessor/RichTextProcessorTest.php
@@ -11,11 +11,12 @@ namespace Ibexa\Tests\FieldTypeRichText\REST\FieldTypeProcessor;
 use DOMDocument;
 use Ibexa\Contracts\FieldTypeRichText\RichText\Converter;
 use Ibexa\FieldTypeRichText\REST\FieldTypeProcessor\RichTextProcessor;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class RichTextProcessorTest extends TestCase
 {
-    public function testPostProcessValueHash()
+    public function testPostProcessValueHash(): void
     {
         $processor = $this->getProcessor();
 
@@ -56,12 +57,12 @@ EOT;
     /**
      * @var \Ibexa\FieldTypeRichText\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $converter;
+    protected ?MockObject $converter = null;
 
     /**
      * @return \Ibexa\FieldTypeRichText\REST\FieldTypeProcessor\RichTextProcessor
      */
-    protected function getProcessor()
+    protected function getProcessor(): RichTextProcessor
     {
         $this->converter = $this->createMock(Converter::class);
 

--- a/tests/lib/RichText/Converter/LinkTest.php
+++ b/tests/lib/RichText/Converter/LinkTest.php
@@ -11,12 +11,15 @@ namespace Ibexa\Tests\FieldTypeRichText\RichText\Converter;
 use DOMDocument;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo as APIContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location as APILocation;
+use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\Base\Exceptions\NotFoundException as APINotFoundException;
+use Ibexa\Core\Base\Exceptions\UnauthorizedException;
 use Ibexa\Core\Base\Exceptions\UnauthorizedException as APIUnauthorizedException;
 use Ibexa\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use Ibexa\Core\Repository\ContentService;
 use Ibexa\Core\Repository\LocationService;
 use Ibexa\FieldTypeRichText\RichText\Converter\Link;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -30,7 +33,7 @@ class LinkTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getMockContentService()
+    protected function getMockContentService(): MockObject
     {
         return $this->createMock(ContentService::class);
     }
@@ -38,7 +41,7 @@ class LinkTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getMockLocationService()
+    protected function getMockLocationService(): MockObject
     {
         return $this->createMock(LocationService::class);
     }
@@ -46,7 +49,7 @@ class LinkTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getMockRouter()
+    protected function getMockRouter(): MockObject
     {
         return $this->createMock(RouterInterface::class);
     }
@@ -54,7 +57,7 @@ class LinkTest extends TestCase
     /**
      * @return array
      */
-    public function providerLinkXmlSample()
+    public function providerLinkXmlSample(): array
     {
         return [
             [
@@ -113,7 +116,7 @@ class LinkTest extends TestCase
      *
      * @dataProvider providerLinkXmlSample
      */
-    public function testLink($input, $output)
+    public function testLink(string $input, string $output): void
     {
         $inputDocument = new DOMDocument();
         $inputDocument->loadXML($input);
@@ -144,7 +147,7 @@ class LinkTest extends TestCase
     /**
      * @return array
      */
-    public function providerLocationLink()
+    public function providerLocationLink(): array
     {
         return [
             [
@@ -209,7 +212,7 @@ class LinkTest extends TestCase
      *
      * @dataProvider providerLocationLink
      */
-    public function testConvertLocationLink($input, $output, $locationId, $urlResolved)
+    public function testConvertLocationLink(string $input, string $output, int $locationId, string $urlResolved): void
     {
         $inputDocument = new DOMDocument();
         $inputDocument->loadXML($input);
@@ -243,7 +246,7 @@ class LinkTest extends TestCase
     /**
      * @return array
      */
-    public function providerBadLocationLink()
+    public function providerBadLocationLink(): array
     {
         return [
             [
@@ -314,7 +317,7 @@ class LinkTest extends TestCase
      *
      * @dataProvider providerBadLocationLink
      */
-    public function testConvertBadLocationLink($input, $output, $locationId, $exception, $logType, $logMessage)
+    public function testConvertBadLocationLink(string $input, string $output, int $locationId, NotFoundException|UnauthorizedException $exception, string $logType, string $logMessage): void
     {
         $inputDocument = new DOMDocument();
         $inputDocument->loadXML($input);
@@ -347,7 +350,7 @@ class LinkTest extends TestCase
     /**
      * @return array
      */
-    public function providerContentLink()
+    public function providerContentLink(): array
     {
         return [
             [
@@ -412,7 +415,7 @@ class LinkTest extends TestCase
      *
      * @dataProvider providerContentLink
      */
-    public function testConvertContentLink($input, $output, $contentId, $urlResolved)
+    public function testConvertContentLink(string $input, string $output, int $contentId, string $urlResolved): void
     {
         $locationId = 106;
         $inputDocument = new DOMDocument();
@@ -458,7 +461,7 @@ class LinkTest extends TestCase
     /**
      * @return array
      */
-    public function providerBadContentLink()
+    public function providerBadContentLink(): array
     {
         return [
             [
@@ -529,7 +532,7 @@ class LinkTest extends TestCase
      *
      * @dataProvider providerBadContentLink
      */
-    public function testConvertBadContentLink($input, $output, $contentId, $exception, $logType, $logMessage)
+    public function testConvertBadContentLink(string $input, string $output, int $contentId, NotFoundException|UnauthorizedException $exception, string $logType, string $logMessage): void
     {
         $inputDocument = new DOMDocument();
         $inputDocument->loadXML($input);

--- a/tests/lib/RichText/Converter/LinkTest.php
+++ b/tests/lib/RichText/Converter/LinkTest.php
@@ -9,11 +9,10 @@ declare(strict_types=1);
 namespace Ibexa\Tests\FieldTypeRichText\RichText\Converter;
 
 use DOMDocument;
+use Exception;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo as APIContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location as APILocation;
-use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\Base\Exceptions\NotFoundException as APINotFoundException;
-use Ibexa\Core\Base\Exceptions\UnauthorizedException;
 use Ibexa\Core\Base\Exceptions\UnauthorizedException as APIUnauthorizedException;
 use Ibexa\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use Ibexa\Core\Repository\ContentService;
@@ -30,32 +29,23 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class LinkTest extends TestCase
 {
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getMockContentService(): MockObject
+    protected function getMockContentService(): ContentService&MockObject
     {
         return $this->createMock(ContentService::class);
     }
 
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getMockLocationService(): MockObject
+    protected function getMockLocationService(): LocationService&MockObject
     {
         return $this->createMock(LocationService::class);
     }
 
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getMockRouter(): MockObject
+    protected function getMockRouter(): RouterInterface&MockObject
     {
         return $this->createMock(RouterInterface::class);
     }
 
     /**
-     * @return array
+     * @return list<array{string, string}>
      */
     public function providerLinkXmlSample(): array
     {
@@ -317,7 +307,7 @@ class LinkTest extends TestCase
      *
      * @dataProvider providerBadLocationLink
      */
-    public function testConvertBadLocationLink(string $input, string $output, int $locationId, NotFoundException|UnauthorizedException $exception, string $logType, string $logMessage): void
+    public function testConvertBadLocationLink(string $input, string $output, int $locationId, Exception $exception, string $logType, string $logMessage): void
     {
         $inputDocument = new DOMDocument();
         $inputDocument->loadXML($input);
@@ -532,7 +522,7 @@ class LinkTest extends TestCase
      *
      * @dataProvider providerBadContentLink
      */
-    public function testConvertBadContentLink(string $input, string $output, int $contentId, NotFoundException|UnauthorizedException $exception, string $logType, string $logMessage): void
+    public function testConvertBadContentLink(string $input, string $output, int $contentId, Exception $exception, string $logType, string $logMessage): void
     {
         $inputDocument = new DOMDocument();
         $inputDocument->loadXML($input);

--- a/tests/lib/RichText/Converter/Render/EmbedTest.php
+++ b/tests/lib/RichText/Converter/Render/EmbedTest.php
@@ -17,6 +17,10 @@ use Psr\Log\LoggerInterface;
 
 class EmbedTest extends TestCase
 {
+    protected RendererInterface&MockObject $rendererMock;
+
+    protected LoggerInterface&MockObject $loggerMock;
+
     public function setUp(): void
     {
         $this->rendererMock = $this->getRendererMock();
@@ -860,28 +864,12 @@ class EmbedTest extends TestCase
         );
     }
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\RendererInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $rendererMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Ibexa\FieldTypeRichText\RichText\RendererInterface
-     */
-    protected function getRendererMock(): MockObject
+    protected function getRendererMock(): RendererInterface&MockObject
     {
         return $this->createMock(RendererInterface::class);
     }
 
-    /**
-     * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $loggerMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\LoggerInterface
-     */
-    protected function getLoggerMock(): MockObject
+    protected function getLoggerMock(): LoggerInterface&MockObject
     {
         return $this->createMock(LoggerInterface::class);
     }

--- a/tests/lib/RichText/Converter/Render/EmbedTest.php
+++ b/tests/lib/RichText/Converter/Render/EmbedTest.php
@@ -11,6 +11,7 @@ namespace Ibexa\Tests\FieldTypeRichText\RichText\Converter\Render;
 use DOMDocument;
 use Ibexa\Contracts\FieldTypeRichText\RichText\RendererInterface;
 use Ibexa\FieldTypeRichText\RichText\Converter\Render\Embed;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -851,7 +852,7 @@ class EmbedTest extends TestCase
         self::assertEquals($expectedDocument, $document);
     }
 
-    protected function getConverter()
+    protected function getConverter(): Embed
     {
         return new Embed(
             $this->rendererMock,
@@ -867,7 +868,7 @@ class EmbedTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|\Ibexa\FieldTypeRichText\RichText\RendererInterface
      */
-    protected function getRendererMock()
+    protected function getRendererMock(): MockObject
     {
         return $this->createMock(RendererInterface::class);
     }
@@ -880,7 +881,7 @@ class EmbedTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|\LoggerInterface
      */
-    protected function getLoggerMock()
+    protected function getLoggerMock(): MockObject
     {
         return $this->createMock(LoggerInterface::class);
     }

--- a/tests/lib/RichText/Converter/Render/TemplateTest.php
+++ b/tests/lib/RichText/Converter/Render/TemplateTest.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\FieldTypeRichText\RichText\Converter;
 use Ibexa\Contracts\FieldTypeRichText\RichText\RendererInterface;
 use Ibexa\FieldTypeRichText\RichText\Converter\Aggregate;
 use Ibexa\FieldTypeRichText\RichText\Converter\Render\Template;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class TemplateTest extends TestCase
@@ -34,7 +35,10 @@ class TemplateTest extends TestCase
         parent::setUp();
     }
 
-    public function providerForTestConvert()
+    /**
+     * @return array{DOMDocument, DOMDocument, mixed}[]
+     */
+    public function providerForTestConvert(): array
     {
         $data = [];
 
@@ -155,7 +159,7 @@ class TemplateTest extends TestCase
         ];
     }
 
-    protected function getConverter()
+    protected function getConverter(): Template
     {
         return new Template(
             $this->rendererMock,
@@ -169,7 +173,7 @@ class TemplateTest extends TestCase
     /**
      * @return \Ibexa\FieldTypeRichText\RichText\RendererInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getRendererMock()
+    protected function getRendererMock(): MockObject
     {
         return $this->createMock(RendererInterface::class);
     }
@@ -177,7 +181,7 @@ class TemplateTest extends TestCase
     /**
      * @return \Ibexa\FieldTypeRichText\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getConverterMock()
+    protected function getConverterMock(): MockObject
     {
         return $this->createMock(Converter::class);
     }

--- a/tests/lib/RichText/Converter/Render/TemplateTest.php
+++ b/tests/lib/RichText/Converter/Render/TemplateTest.php
@@ -18,15 +18,9 @@ use PHPUnit\Framework\TestCase;
 
 class TemplateTest extends TestCase
 {
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\RendererInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $rendererMock;
+    protected RendererInterface&MockObject $rendererMock;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $converterMock;
+    protected Converter&MockObject $converterMock;
 
     public function setUp(): void
     {
@@ -170,18 +164,12 @@ class TemplateTest extends TestCase
         );
     }
 
-    /**
-     * @return \Ibexa\FieldTypeRichText\RichText\RendererInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getRendererMock(): MockObject
+    protected function getRendererMock(): RendererInterface&MockObject
     {
         return $this->createMock(RendererInterface::class);
     }
 
-    /**
-     * @return \Ibexa\FieldTypeRichText\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getConverterMock(): MockObject
+    protected function getConverterMock(): Converter&MockObject
     {
         return $this->createMock(Converter::class);
     }

--- a/tests/lib/RichText/Converter/Xslt/BaseTest.php
+++ b/tests/lib/RichText/Converter/Xslt/BaseTest.php
@@ -85,7 +85,7 @@ abstract class BaseTest extends TestCase
      *
      * @dataProvider providerForTestConvert
      */
-    public function testConvert($inputFile, $outputFile)
+    public function testConvert($inputFile, string $outputFile): void
     {
         $endsWith = '.lossy.xml';
         if (substr_compare($inputFile, $endsWith, -strlen($endsWith), strlen($endsWith)) === 0) {

--- a/tests/lib/RichText/Converter/Xslt/DocbookToXhtml5EditTest.php
+++ b/tests/lib/RichText/Converter/Xslt/DocbookToXhtml5EditTest.php
@@ -30,7 +30,7 @@ class DocbookToXhtml5EditTest extends BaseTest
      *
      * @return array
      */
-    public function getFixtureSubdirectories()
+    public function getFixtureSubdirectories(): array
     {
         return [
             'input' => 'docbook',
@@ -43,7 +43,7 @@ class DocbookToXhtml5EditTest extends BaseTest
      *
      * @return string
      */
-    protected function getConversionTransformationStylesheet()
+    protected function getConversionTransformationStylesheet(): string
     {
         return __DIR__ . '/../../../../../src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/edit/xhtml5.xsl';
     }
@@ -70,7 +70,7 @@ class DocbookToXhtml5EditTest extends BaseTest
      *
      * @return array
      */
-    protected function getCustomConversionTransformationStylesheets()
+    protected function getCustomConversionTransformationStylesheets(): array
     {
         return [
             [

--- a/tests/lib/RichText/Converter/Xslt/DocbookToXhtml5OutputTest.php
+++ b/tests/lib/RichText/Converter/Xslt/DocbookToXhtml5OutputTest.php
@@ -35,7 +35,7 @@ class DocbookToXhtml5OutputTest extends BaseTest
      *
      * @return array
      */
-    public function getFixtureSubdirectories()
+    public function getFixtureSubdirectories(): array
     {
         return [
             'input' => 'docbook',
@@ -48,7 +48,7 @@ class DocbookToXhtml5OutputTest extends BaseTest
      *
      * @return string
      */
-    protected function getConversionTransformationStylesheet()
+    protected function getConversionTransformationStylesheet(): string
     {
         return __DIR__ . '/../../../../../src/bundle/Resources/richtext/stylesheets/docbook/xhtml5/output/xhtml5.xsl';
     }
@@ -75,7 +75,7 @@ class DocbookToXhtml5OutputTest extends BaseTest
      *
      * @return array
      */
-    protected function getCustomConversionTransformationStylesheets()
+    protected function getCustomConversionTransformationStylesheets(): array
     {
         return [
             [

--- a/tests/lib/RichText/Converter/Xslt/Xhtml5ToDocbookTest.php
+++ b/tests/lib/RichText/Converter/Xslt/Xhtml5ToDocbookTest.php
@@ -35,7 +35,7 @@ class Xhtml5ToDocbookTest extends BaseTest
      *
      * @return array
      */
-    public function getFixtureSubdirectories()
+    public function getFixtureSubdirectories(): array
     {
         return [
             'input' => 'xhtml5/edit',
@@ -48,7 +48,7 @@ class Xhtml5ToDocbookTest extends BaseTest
      *
      * @return string
      */
-    protected function getConversionTransformationStylesheet()
+    protected function getConversionTransformationStylesheet(): string
     {
         return __DIR__ . '/../../../../../src/bundle/Resources/richtext/stylesheets/xhtml5/edit/docbook.xsl';
     }
@@ -75,7 +75,7 @@ class Xhtml5ToDocbookTest extends BaseTest
      *
      * @return array
      */
-    protected function getCustomConversionTransformationStylesheets()
+    protected function getCustomConversionTransformationStylesheets(): array
     {
         return [
             [
@@ -90,7 +90,7 @@ class Xhtml5ToDocbookTest extends BaseTest
      *
      * @return string[]
      */
-    protected function getConversionValidationSchema()
+    protected function getConversionValidationSchema(): array
     {
         return [
             __DIR__ . '/_fixtures/docbook/custom_schemas/youtube.rng',

--- a/tests/lib/RichText/DOMDocumentFactoryTest.php
+++ b/tests/lib/RichText/DOMDocumentFactoryTest.php
@@ -19,7 +19,7 @@ class DOMDocumentFactoryTest extends TestCase
     /**
      * @var \Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory
      */
-    private $domDocumentFactory;
+    private DOMDocumentFactory $domDocumentFactory;
 
     /**
      * {@inheritdoc}

--- a/tests/lib/RichText/DOMDocumentFactoryTest.php
+++ b/tests/lib/RichText/DOMDocumentFactoryTest.php
@@ -16,14 +16,8 @@ use PHPUnit\Framework\TestCase;
 
 class DOMDocumentFactoryTest extends TestCase
 {
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory
-     */
     private DOMDocumentFactory $domDocumentFactory;
 
-    /**
-     * {@inheritdoc}
-     */
     protected function setUp(): void
     {
         $this->domDocumentFactory = new DOMDocumentFactory(new XMLSanitizer());

--- a/tests/lib/RichText/InputHandlerTest.php
+++ b/tests/lib/RichText/InputHandlerTest.php
@@ -23,44 +23,20 @@ use PHPUnit\Framework\TestCase;
 
 class InputHandlerTest extends TestCase
 {
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory|\PHPUnit\Framework\MockObject\MockObject
-     */
     private DOMDocumentFactory $domDocumentFactory;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\ConverterDispatcher|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $converter;
+    private ConverterDispatcher&MockObject $converter;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\Normalizer|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $normalizer;
+    private Normalizer&MockObject $normalizer;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\ValidatorInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $schemaValidator;
+    private ValidatorInterface&MockObject $schemaValidator;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\ValidatorInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $docbookValidator;
+    private ValidatorInterface&MockObject $docbookValidator;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\RelationProcessor
-     */
     private RelationProcessor $relationProcessor;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\InputHandler|\PHPUnit\Framework\MockObject\MockObject
-     */
     private InputHandler $inputHandler;
 
-    /**
-     * {@inheritdoc}
-     */
     protected function setUp(): void
     {
         $this->domDocumentFactory = new DOMDocumentFactory(new XMLSanitizer());
@@ -117,7 +93,7 @@ class InputHandlerTest extends TestCase
         $inputHandler
             ->expects(self::once())
             ->method('fromDocument')
-            ->willReturnCallback(function (DOMDocument $document) use ($inputXml, $outputDocument): \PHPUnit\Framework\MockObject\MockObject {
+            ->willReturnCallback(function (DOMDocument $document) use ($inputXml, $outputDocument): DOMDocument {
                 $this->assertEquals($inputXml, $document->saveXML());
 
                 return $outputDocument;

--- a/tests/lib/RichText/InputHandlerTest.php
+++ b/tests/lib/RichText/InputHandlerTest.php
@@ -18,6 +18,7 @@ use Ibexa\FieldTypeRichText\RichText\InputHandler;
 use Ibexa\FieldTypeRichText\RichText\Normalizer;
 use Ibexa\FieldTypeRichText\RichText\RelationProcessor;
 use Ibexa\FieldTypeRichText\RichText\XMLSanitizer;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class InputHandlerTest extends TestCase
@@ -25,37 +26,37 @@ class InputHandlerTest extends TestCase
     /**
      * @var \Ibexa\FieldTypeRichText\RichText\DOMDocumentFactory|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $domDocumentFactory;
+    private DOMDocumentFactory $domDocumentFactory;
 
     /**
      * @var \Ibexa\FieldTypeRichText\RichText\ConverterDispatcher|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $converter;
+    private MockObject $converter;
 
     /**
      * @var \Ibexa\FieldTypeRichText\RichText\Normalizer|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $normalizer;
+    private MockObject $normalizer;
 
     /**
      * @var \Ibexa\FieldTypeRichText\RichText\ValidatorInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $schemaValidator;
+    private MockObject $schemaValidator;
 
     /**
      * @var \Ibexa\FieldTypeRichText\RichText\ValidatorInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $docbookValidator;
+    private MockObject $docbookValidator;
 
     /**
      * @var \Ibexa\FieldTypeRichText\RichText\RelationProcessor
      */
-    private $relationProcessor;
+    private RelationProcessor $relationProcessor;
 
     /**
      * @var \Ibexa\FieldTypeRichText\RichText\InputHandler|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $inputHandler;
+    private InputHandler $inputHandler;
 
     /**
      * {@inheritdoc}
@@ -116,7 +117,7 @@ class InputHandlerTest extends TestCase
         $inputHandler
             ->expects(self::once())
             ->method('fromDocument')
-            ->willReturnCallback(function (DOMDocument $document) use ($inputXml, $outputDocument) {
+            ->willReturnCallback(function (DOMDocument $document) use ($inputXml, $outputDocument): \PHPUnit\Framework\MockObject\MockObject {
                 $this->assertEquals($inputXml, $document->saveXML());
 
                 return $outputDocument;

--- a/tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
+++ b/tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class DocumentTypeDefinitionTest extends TestCase
 {
-    public function providerForTestNormalize()
+    public function providerForTestNormalize(): array
     {
         return [
             [
@@ -86,7 +86,7 @@ xmlns="http://ibexa.co/namespaces/ezpublish5/xhtml5/edit">
      * @param string $dtdPath
      * @param string $input
      */
-    public function testAccept($documentElement, $namespace, $dtdPath, $input)
+    public function testAccept(string $documentElement, string $namespace, string $dtdPath, string $input): void
     {
         $normalizer = $this->getNormalizer($documentElement, $namespace, $dtdPath);
 
@@ -101,7 +101,7 @@ xmlns="http://ibexa.co/namespaces/ezpublish5/xhtml5/edit">
      * @param string $dtdPath
      * @param string $input Ignored
      */
-    public function testAcceptNoXmlDeclaration($documentElement, $namespace, $dtdPath, $input)
+    public function testAcceptNoXmlDeclaration(string $documentElement, string $namespace, string $dtdPath, string $input): void
     {
         $normalizer = $this->getNormalizer($documentElement, $namespace, $dtdPath);
 
@@ -127,7 +127,7 @@ XML
      * @param string $expectedOutput
      * @param string $expectedSaved
      */
-    public function testNormalize($documentElement, $namespace, $dtdPath, $input, $expectedOutput, $expectedSaved)
+    public function testNormalize(string $documentElement, string $namespace, string $dtdPath, string $input, string $expectedOutput, string $expectedSaved): void
     {
         $normalizer = $this->getNormalizer($documentElement, $namespace, $dtdPath);
 
@@ -143,7 +143,7 @@ XML
         self::assertEquals($expectedDocument, $normalizedDocument);
     }
 
-    public function providerForTestRefuse()
+    public function providerForTestRefuse(): array
     {
         return [
             [
@@ -205,14 +205,14 @@ XML
      * @param string $dtdPath
      * @param string $input
      */
-    public function testRefuse($documentElement, $namespace, $dtdPath, $input)
+    public function testRefuse(string $documentElement, string $namespace, string $dtdPath, string $input): void
     {
         $normalizer = $this->getNormalizer($documentElement, $namespace, $dtdPath);
 
         self::assertFalse($normalizer->accept($input));
     }
 
-    protected function getNormalizer($documentElement, $namespace, $dtdPath)
+    protected function getNormalizer($documentElement, $namespace, $dtdPath): DocumentTypeDefinition
     {
         return new DocumentTypeDefinition($documentElement, $namespace, $dtdPath);
     }

--- a/tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
+++ b/tests/lib/RichText/Normalizer/DocumentTypeDefinitionTest.php
@@ -14,6 +14,9 @@ use PHPUnit\Framework\TestCase;
 
 class DocumentTypeDefinitionTest extends TestCase
 {
+    /**
+     * @phpstan-return list<array{string, string, string, string, string, string}>
+     */
     public function providerForTestNormalize(): array
     {
         return [
@@ -131,7 +134,7 @@ XML
     {
         $normalizer = $this->getNormalizer($documentElement, $namespace, $dtdPath);
 
-        $output = $normalizer->normalize($input);
+        $output = (string)$normalizer->normalize($input);
 
         self::assertEquals($expectedOutput, $output);
 
@@ -143,6 +146,9 @@ XML
         self::assertEquals($expectedDocument, $normalizedDocument);
     }
 
+    /**
+     * @phpstan-return list<array{string, string, string, string}>
+     */
     public function providerForTestRefuse(): array
     {
         return [

--- a/tests/lib/RichText/RendererTest.php
+++ b/tests/lib/RichText/RendererTest.php
@@ -17,6 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\FieldTypeRichText\RichText\Renderer;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -37,7 +38,7 @@ class RendererTest extends TestCase
         parent::setUp();
     }
 
-    public function testRenderTag()
+    public function testRenderTag(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'getTagTemplateName']);
         $name = 'tag';
@@ -78,7 +79,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderTagNoTemplateConfigured()
+    public function testRenderTagNoTemplateConfigured(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'getTagTemplateName']);
         $name = 'tag';
@@ -109,7 +110,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderTagNoTemplateFound()
+    public function testRenderTagNoTemplateFound(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'getTagTemplateName']);
         $name = 'tag';
@@ -291,13 +292,13 @@ class RendererTest extends TestCase
      * @dataProvider providerForTestRenderTagWithTemplate
      */
     public function testRenderTagWithTemplate(
-        $tagName,
+        string $tagName,
         array $configResolverParams,
         array $loggerParams,
-        $templateEngineTemplate,
-        $renderTemplate,
-        $isInline,
-        $renderResult
+        ?string $templateEngineTemplate,
+        ?string $renderTemplate,
+        bool $isInline,
+        ?string $renderResult
     ): void {
         $renderer = $this->getMockedRenderer(['render']);
         $parameters = ['parameters'];
@@ -384,7 +385,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderContentEmbed()
+    public function testRenderContentEmbed(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkContentPermissions', 'getEmbedTemplateName']);
         $contentId = 42;
@@ -441,7 +442,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderContentEmbedNoTemplateConfigured()
+    public function testRenderContentEmbedNoTemplateConfigured(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkContentPermissions', 'getEmbedTemplateName']);
         $contentId = 42;
@@ -489,7 +490,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderContentEmbedNoTemplateFound()
+    public function testRenderContentEmbedNoTemplateFound(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkContentPermissions', 'getEmbedTemplateName']);
         $contentId = 42;
@@ -542,7 +543,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderContentEmbedAccessDenied()
+    public function testRenderContentEmbedAccessDenied(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkContentPermissions', 'getEmbedTemplateName']);
         $contentId = 42;
@@ -600,7 +601,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderContentEmbedTrashed()
+    public function testRenderContentEmbedTrashed(): void
     {
         $renderer = $this->getMockedRenderer(['checkContentPermissions']);
         $contentId = 42;
@@ -637,7 +638,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderContentEmbedHidden()
+    public function testRenderContentEmbedHidden(): void
     {
         $renderer = $this->getMockedRenderer(['checkContentPermissions']);
         $contentId = 42;
@@ -678,7 +679,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function providerForTestRenderContentEmbedNotFound()
+    public function providerForTestRenderContentEmbedNotFound(): array
     {
         return [
             [new NotFoundException('Content', 42)],
@@ -689,7 +690,7 @@ class RendererTest extends TestCase
     /**
      * @dataProvider providerForTestRenderContentEmbedNotFound
      */
-    public function testRenderContentEmbedNotFound(Exception $exception)
+    public function testRenderContentEmbedNotFound(Exception $exception): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkContentPermissions', 'getEmbedTemplateName']);
         $contentId = 42;
@@ -735,7 +736,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderContentEmbedThrowsException()
+    public function testRenderContentEmbedThrowsException(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Something threw up');
@@ -760,7 +761,7 @@ class RendererTest extends TestCase
         $renderer->renderContentEmbed($contentId, 'embedTest', ['parameters'], true);
     }
 
-    public function providerForTestRenderContentWithTemplate()
+    public function providerForTestRenderContentWithTemplate(): array
     {
         $contentId = 42;
 
@@ -956,13 +957,13 @@ class RendererTest extends TestCase
      * @dataProvider providerForTestRenderContentWithTemplate
      */
     public function testRenderContentWithTemplate(
-        $isInline,
-        $deniedException,
+        bool $isInline,
+        ?AccessDeniedException $deniedException,
         array $configResolverParams,
         array $loggerParams,
-        $templateEngineTemplate,
-        $renderTemplate,
-        $renderResult
+        ?string $templateEngineTemplate,
+        ?string $renderTemplate,
+        ?string $renderResult
     ): void {
         $renderer = $this->getMockedRenderer(['render', 'checkContentPermissions']);
         $contentId = 42;
@@ -1073,7 +1074,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderLocationEmbed()
+    public function testRenderLocationEmbed(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkLocation', 'getEmbedTemplateName']);
         $locationId = 42;
@@ -1129,7 +1130,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderLocationEmbedNoTemplateConfigured()
+    public function testRenderLocationEmbedNoTemplateConfigured(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkLocation', 'getEmbedTemplateName']);
         $locationId = 42;
@@ -1176,7 +1177,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderLocationEmbedNoTemplateFound()
+    public function testRenderLocationEmbedNoTemplateFound(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkLocation', 'getEmbedTemplateName']);
         $locationId = 42;
@@ -1229,7 +1230,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderLocationEmbedAccessDenied()
+    public function testRenderLocationEmbedAccessDenied(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkLocation', 'getEmbedTemplateName']);
         $locationId = 42;
@@ -1279,7 +1280,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderLocationEmbedInvisible()
+    public function testRenderLocationEmbedInvisible(): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkLocation', 'getEmbedTemplateName']);
         $locationId = 42;
@@ -1322,7 +1323,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function providerForTestRenderLocationEmbedNotFound()
+    public function providerForTestRenderLocationEmbedNotFound(): array
     {
         return [
             [new NotFoundException('Location', 42)],
@@ -1333,7 +1334,7 @@ class RendererTest extends TestCase
     /**
      * @dataProvider providerForTestRenderLocationEmbedNotFound
      */
-    public function testRenderLocationEmbedNotFound(Exception $exception)
+    public function testRenderLocationEmbedNotFound(Exception $exception): void
     {
         $renderer = $this->getMockedRenderer(['render', 'checkLocation', 'getEmbedTemplateName']);
         $locationId = 42;
@@ -1371,7 +1372,7 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderLocationEmbedThrowsException()
+    public function testRenderLocationEmbedThrowsException(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Something threw up');
@@ -1388,7 +1389,7 @@ class RendererTest extends TestCase
         $renderer->renderLocationEmbed($locationId, 'embedTest', ['parameters'], true);
     }
 
-    public function providerForTestRenderLocationWithTemplate()
+    public function providerForTestRenderLocationWithTemplate(): array
     {
         $locationId = 42;
 
@@ -1580,14 +1581,14 @@ class RendererTest extends TestCase
      * @dataProvider providerForTestRenderLocationWithTemplate
      */
     public function testRenderLocationWithTemplate(
-        $isInline,
-        $deniedException,
+        bool $isInline,
+        ?AccessDeniedException $deniedException,
         array $configResolverParams,
         array $loggerParams,
-        $templateEngineTemplate,
-        $renderTemplate,
-        $renderResult
-    ) {
+        ?string $templateEngineTemplate,
+        ?string $renderTemplate,
+        ?string $renderResult
+    ): void {
         $renderer = $this->getMockedRenderer(['render', 'checkLocation']);
         $locationId = 42;
         $viewType = 'embedTest';
@@ -1701,7 +1702,7 @@ class RendererTest extends TestCase
      *
      * @return \Ibexa\FieldTypeRichText\RichText\Renderer|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getMockedRenderer(array $methods = [])
+    protected function getMockedRenderer(array $methods = []): MockObject
     {
         return $this->getMockBuilder(Renderer::class)
             ->setConstructorArgs(
@@ -1788,7 +1789,7 @@ class RendererTest extends TestCase
         return $this->createMock(LoaderInterface::class);
     }
 
-    protected function getContentMock($mainLocationId)
+    protected function getContentMock($mainLocationId): MockObject
     {
         $contentInfoMock = $this->createMock(ContentInfo::class);
         $contentInfoMock

--- a/tests/lib/RichText/RendererTest.php
+++ b/tests/lib/RichText/RendererTest.php
@@ -679,6 +679,9 @@ class RendererTest extends TestCase
         );
     }
 
+    /**
+     * @phpstan-return list<array{\Exception}>
+     */
     public function providerForTestRenderContentEmbedNotFound(): array
     {
         return [
@@ -761,6 +764,9 @@ class RendererTest extends TestCase
         $renderer->renderContentEmbed($contentId, 'embedTest', ['parameters'], true);
     }
 
+    /**
+     * @phpstan-return list<array{bool, \Exception|null, mixed[], mixed[], string|null, string|null, string|null}>
+     */
     public function providerForTestRenderContentWithTemplate(): array
     {
         $contentId = 42;
@@ -1323,6 +1329,9 @@ class RendererTest extends TestCase
         );
     }
 
+    /**
+     * @phpstan-return list<array{\Exception}>
+     */
     public function providerForTestRenderLocationEmbedNotFound(): array
     {
         return [
@@ -1389,6 +1398,9 @@ class RendererTest extends TestCase
         $renderer->renderLocationEmbed($locationId, 'embedTest', ['parameters'], true);
     }
 
+    /**
+     * @phpstan-return list<array{bool, \Exception|null, mixed[], mixed[], string|null, string|null, string|null}>
+     */
     public function providerForTestRenderLocationWithTemplate(): array
     {
         $locationId = 42;

--- a/tests/lib/RichText/Validator/CustomTagsValidatorTest.php
+++ b/tests/lib/RichText/Validator/CustomTagsValidatorTest.php
@@ -37,7 +37,7 @@ final class CustomTagsValidatorTest extends TestCase
      * @param \DOMDocument $document
      * @param array $expectedErrors
      */
-    public function testValidateDocument(DOMDocument $document, array $expectedErrors)
+    public function testValidateDocument(DOMDocument $document, array $expectedErrors): void
     {
         self::assertEquals(
             $expectedErrors,
@@ -52,7 +52,7 @@ final class CustomTagsValidatorTest extends TestCase
      *
      * @return array
      */
-    public function providerForTestValidateDocument()
+    public function providerForTestValidateDocument(): array
     {
         return [
             [
@@ -186,7 +186,7 @@ DOCBOOK
      *
      * @return \DOMDocument
      */
-    protected function createDocument($source)
+    protected function createDocument($source): DOMDocument
     {
         $document = new DOMDocument();
 

--- a/tests/lib/RichText/Validator/DocbookTest.php
+++ b/tests/lib/RichText/Validator/DocbookTest.php
@@ -9,11 +9,17 @@ declare(strict_types=1);
 namespace Ibexa\Tests\FieldTypeRichText\RichText\Validator;
 
 use DOMDocument;
+use Ibexa\Contracts\FieldTypeRichText\RichText\ValidatorInterface;
 use Ibexa\FieldTypeRichText\RichText\Validator\Validator;
 use PHPUnit\Framework\TestCase;
 
 class DocbookTest extends TestCase
 {
+    protected ?ValidatorInterface $validator = null;
+
+    /**
+     * @phpstan-return list<array{string, string[]}>
+     */
     public function providerForTestValidate(): array
     {
         return [
@@ -154,6 +160,8 @@ class DocbookTest extends TestCase
 
     /**
      * @dataProvider providerForTestValidate
+     *
+     * @param string[] $expectedErrors
      */
     public function testValidate(string $input, array $expectedErrors): void
     {
@@ -170,19 +178,10 @@ class DocbookTest extends TestCase
         }
     }
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\ValidatorInterface
-     */
-    protected $validator;
-
-    /**
-     * @return \Ibexa\FieldTypeRichText\RichText\ValidatorInterface
-     */
-    protected function getConversionValidator()
+    protected function getConversionValidator(): ValidatorInterface
     {
-        $validationSchema = $this->getConversionValidationSchemas();
-        if ($validationSchema !== null && $this->validator === null) {
-            $this->validator = new Validator($validationSchema);
+        if ($this->validator === null) {
+            $this->validator = new Validator($this->getConversionValidationSchemas());
         }
 
         return $this->validator;

--- a/tests/lib/RichText/Validator/DocbookTest.php
+++ b/tests/lib/RichText/Validator/DocbookTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class DocbookTest extends TestCase
 {
-    public function providerForTestValidate()
+    public function providerForTestValidate(): array
     {
         return [
             [
@@ -155,7 +155,7 @@ class DocbookTest extends TestCase
     /**
      * @dataProvider providerForTestValidate
      */
-    public function testValidate($input, $expectedErrors)
+    public function testValidate(string $input, array $expectedErrors): void
     {
         $document = new DOMDocument();
         $document->loadXML($input);
@@ -193,7 +193,7 @@ class DocbookTest extends TestCase
      *
      * @return string[]
      */
-    protected function getConversionValidationSchemas()
+    protected function getConversionValidationSchemas(): array
     {
         return [
             __DIR__ . '/../../../../src/bundle/Resources/richtext/schemas/docbook/ezpublish.rng',

--- a/tests/lib/RichText/Validator/InternalLinkValidatorTest.php
+++ b/tests/lib/RichText/Validator/InternalLinkValidatorTest.php
@@ -18,11 +18,9 @@ use PHPUnit\Framework\TestCase;
 
 class InternalLinkValidatorTest extends TestCase
 {
-    /** @var \Ibexa\Contracts\Core\Persistence\Content\Handler|\PHPUnit\Framework\MockObject\MockObject */
-    private ?MockObject $contentHandler = null;
+    private ContentHandler&MockObject $contentHandler;
 
-    /** @var \Ibexa\Contracts\Core\Persistence\Content\Location\Handler|\PHPUnit\Framework\MockObject\MockObject */
-    private ?MockObject $locationHandler = null;
+    private LocationHandler&MockObject $locationHandler;
 
     /**
      * @before
@@ -39,7 +37,7 @@ class InternalLinkValidatorTest extends TestCase
         $this->expectExceptionMessage("Argument 'eznull' is invalid: The provided scheme 'eznull' is not supported.");
 
         $validator = $this->getInternalLinkValidator();
-        $validator->validate('eznull', 1);
+        $validator->validate('eznull', '1');
     }
 
     public function testValidateEzContentWithExistingContentId(): void
@@ -52,7 +50,7 @@ class InternalLinkValidatorTest extends TestCase
             ->method('loadContentInfo')
             ->with($contentId);
 
-        self::assertTrue($validator->validate('ezcontent', $contentId));
+        self::assertTrue($validator->validate('ezcontent', (string)$contentId));
     }
 
     public function testValidateEzContentNonExistingContentId(): void
@@ -68,7 +66,7 @@ class InternalLinkValidatorTest extends TestCase
             ->with($contentId)
             ->willThrowException($exception);
 
-        self::assertFalse($validator->validate('ezcontent', $contentId));
+        self::assertFalse($validator->validate('ezcontent', (string)$contentId));
     }
 
     public function testValidateEzLocationWithExistingLocationId(): void
@@ -82,7 +80,7 @@ class InternalLinkValidatorTest extends TestCase
             ->method('load')
             ->with($locationId);
 
-        self::assertTrue($validator->validate('ezlocation', $locationId));
+        self::assertTrue($validator->validate('ezlocation', (string)$locationId));
     }
 
     public function testValidateEzLocationWithNonExistingLocationId(): void
@@ -98,7 +96,7 @@ class InternalLinkValidatorTest extends TestCase
             ->with($locationId)
             ->willThrowException($exception);
 
-        self::assertFalse($validator->validate('ezlocation', $locationId));
+        self::assertFalse($validator->validate('ezlocation', (string)$locationId));
     }
 
     public function testValidateEzRemoteWithExistingRemoteId(): void
@@ -287,10 +285,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertContains(sprintf($format, $contentId), $errors);
     }
 
-    /**
-     * @return \Ibexa\FieldTypeRichText\FieldType\RichText\InternalLinkValidator|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private function getInternalLinkValidator(array $methods = null): MockObject
+    private function getInternalLinkValidator(array $methods = null): InternalLinkValidator&MockObject
     {
         return $this->getMockBuilder(InternalLinkValidator::class)
             ->setMethods($methods)

--- a/tests/lib/RichText/Validator/InternalLinkValidatorTest.php
+++ b/tests/lib/RichText/Validator/InternalLinkValidatorTest.php
@@ -13,26 +13,27 @@ use Ibexa\Contracts\Core\Persistence\Content\Location\Handler as LocationHandler
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\FieldTypeRichText\RichText\Validator\InternalLinkValidator;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class InternalLinkValidatorTest extends TestCase
 {
     /** @var \Ibexa\Contracts\Core\Persistence\Content\Handler|\PHPUnit\Framework\MockObject\MockObject */
-    private $contentHandler;
+    private ?MockObject $contentHandler = null;
 
     /** @var \Ibexa\Contracts\Core\Persistence\Content\Location\Handler|\PHPUnit\Framework\MockObject\MockObject */
-    private $locationHandler;
+    private ?MockObject $locationHandler = null;
 
     /**
      * @before
      */
-    public function setupInternalLinkValidator()
+    public function setupInternalLinkValidator(): void
     {
         $this->contentHandler = $this->createMock(ContentHandler::class);
         $this->locationHandler = $this->createMock(LocationHandler::class);
     }
 
-    public function testValidateFailOnNotSupportedSchema()
+    public function testValidateFailOnNotSupportedSchema(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Argument 'eznull' is invalid: The provided scheme 'eznull' is not supported.");
@@ -41,7 +42,7 @@ class InternalLinkValidatorTest extends TestCase
         $validator->validate('eznull', 1);
     }
 
-    public function testValidateEzContentWithExistingContentId()
+    public function testValidateEzContentWithExistingContentId(): void
     {
         $validator = $this->getInternalLinkValidator();
 
@@ -54,7 +55,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertTrue($validator->validate('ezcontent', $contentId));
     }
 
-    public function testValidateEzContentNonExistingContentId()
+    public function testValidateEzContentNonExistingContentId(): void
     {
         $validator = $this->getInternalLinkValidator();
 
@@ -70,7 +71,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertFalse($validator->validate('ezcontent', $contentId));
     }
 
-    public function testValidateEzLocationWithExistingLocationId()
+    public function testValidateEzLocationWithExistingLocationId(): void
     {
         $validator = $this->getInternalLinkValidator();
 
@@ -84,7 +85,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertTrue($validator->validate('ezlocation', $locationId));
     }
 
-    public function testValidateEzLocationWithNonExistingLocationId()
+    public function testValidateEzLocationWithNonExistingLocationId(): void
     {
         $validator = $this->getInternalLinkValidator();
 
@@ -100,7 +101,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertFalse($validator->validate('ezlocation', $locationId));
     }
 
-    public function testValidateEzRemoteWithExistingRemoteId()
+    public function testValidateEzRemoteWithExistingRemoteId(): void
     {
         $validator = $this->getInternalLinkValidator();
 
@@ -114,7 +115,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertTrue($validator->validate('ezremote', $contentRemoteId));
     }
 
-    public function testValidateEzRemoteWithNonExistingRemoteId()
+    public function testValidateEzRemoteWithNonExistingRemoteId(): void
     {
         $validator = $this->getInternalLinkValidator();
 
@@ -130,7 +131,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertFalse($validator->validate('ezremote', $contentRemoteId));
     }
 
-    public function testValidateDocumentSkipMissingTargetId()
+    public function testValidateDocumentSkipMissingTargetId(): void
     {
         $scheme = 'ezcontent';
         $contentId = null;
@@ -148,7 +149,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertEmpty($errors);
     }
 
-    public function testValidateDocumentEzContentExistingContentId()
+    public function testValidateDocumentEzContentExistingContentId(): void
     {
         $scheme = 'ezcontent';
         $contentId = 1;
@@ -167,7 +168,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertEmpty($errors);
     }
 
-    public function testValidateDocumentEzContentNonExistingContentId()
+    public function testValidateDocumentEzContentNonExistingContentId(): void
     {
         $scheme = 'ezcontent';
         $contentId = 1;
@@ -187,7 +188,7 @@ class InternalLinkValidatorTest extends TestCase
         $this->assertContainsEzContentInvalidLinkError($contentId, $errors);
     }
 
-    public function testValidateDocumentEzContentExistingLocationId()
+    public function testValidateDocumentEzContentExistingLocationId(): void
     {
         $scheme = 'ezlocation';
         $locationId = 1;
@@ -206,7 +207,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertEmpty($errors);
     }
 
-    public function testValidateDocumentEzContentNonExistingLocationId()
+    public function testValidateDocumentEzContentNonExistingLocationId(): void
     {
         $scheme = 'ezlocation';
         $locationId = 1;
@@ -226,7 +227,7 @@ class InternalLinkValidatorTest extends TestCase
         $this->assertContainsEzLocationInvalidLinkError($locationId, $errors);
     }
 
-    public function testValidateDocumentEzRemoteExistingId()
+    public function testValidateDocumentEzRemoteExistingId(): void
     {
         $scheme = 'ezremote';
         $contentRemoteId = '0ba685755118cf95abb0fe25f3f6a1c8';
@@ -245,7 +246,7 @@ class InternalLinkValidatorTest extends TestCase
         self::assertEmpty($errors);
     }
 
-    public function testValidateDocumentEzRemoteNonExistingId()
+    public function testValidateDocumentEzRemoteNonExistingId(): void
     {
         $scheme = 'ezremote';
         $contentRemoteId = '0ba685755118cf95abb0fe25f3f6a1c8';
@@ -265,21 +266,21 @@ class InternalLinkValidatorTest extends TestCase
         $this->assertContainsEzRemoteInvalidLinkError($contentRemoteId, $errors);
     }
 
-    private function assertContainsEzLocationInvalidLinkError($locationId, array $errors)
+    private function assertContainsEzLocationInvalidLinkError(int $locationId, array $errors): void
     {
         $format = 'Invalid link "ezlocation://%d": cannot find target Location';
 
         self::assertContains(sprintf($format, $locationId), $errors);
     }
 
-    private function assertContainsEzContentInvalidLinkError($contentId, array $errors)
+    private function assertContainsEzContentInvalidLinkError(int $contentId, array $errors): void
     {
         $format = 'Invalid link "ezcontent://%d": cannot find target content';
 
         self::assertContains(sprintf($format, $contentId), $errors);
     }
 
-    private function assertContainsEzRemoteInvalidLinkError($contentId, array $errors)
+    private function assertContainsEzRemoteInvalidLinkError(string $contentId, array $errors): void
     {
         $format = 'Invalid link "ezremote://%s": cannot find target content';
 
@@ -289,7 +290,7 @@ class InternalLinkValidatorTest extends TestCase
     /**
      * @return \Ibexa\FieldTypeRichText\FieldType\RichText\InternalLinkValidator|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function getInternalLinkValidator(array $methods = null)
+    private function getInternalLinkValidator(array $methods = null): MockObject
     {
         return $this->getMockBuilder(InternalLinkValidator::class)
             ->setMethods($methods)
@@ -300,7 +301,7 @@ class InternalLinkValidatorTest extends TestCase
             ->getMock();
     }
 
-    private function createInputDocument($scheme, $id)
+    private function createInputDocument(string $scheme, null|int|string $id): \DOMDocument
     {
         $url = $scheme . '://' . $id;
         $xml = '<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/lib/Validator/Constraints/RichTextValidatorTest.php
+++ b/tests/lib/Validator/Constraints/RichTextValidatorTest.php
@@ -21,19 +21,10 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class RichTextValidatorTest extends TestCase
 {
-    /**
-     * @var \Ibexa\FieldTypeRichText\RichText\InputHandlerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $inputHandler;
+    private InputHandlerInterface&MockObject $inputHandler;
 
-    /**
-     * @var \Symfony\Component\Validator\Context\ExecutionContextInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $executionContext;
+    private ExecutionContextInterface&MockObject $executionContext;
 
-    /**
-     * @var \Ibexa\FieldTypeRichText\Validator\Constraints\RichTextValidator
-     */
     private RichTextValidator $validator;
 
     protected function setUp(): void

--- a/tests/lib/Validator/Constraints/RichTextValidatorTest.php
+++ b/tests/lib/Validator/Constraints/RichTextValidatorTest.php
@@ -14,6 +14,7 @@ use Ibexa\FieldTypeRichText\RichText\Exception\InvalidXmlException;
 use Ibexa\FieldTypeRichText\Validator\Constraints\RichText;
 use Ibexa\FieldTypeRichText\Validator\Constraints\RichTextValidator;
 use LibXMLError;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
@@ -23,17 +24,17 @@ class RichTextValidatorTest extends TestCase
     /**
      * @var \Ibexa\FieldTypeRichText\RichText\InputHandlerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $inputHandler;
+    private MockObject $inputHandler;
 
     /**
      * @var \Symfony\Component\Validator\Context\ExecutionContextInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $executionContext;
+    private MockObject $executionContext;
 
     /**
      * @var \Ibexa\FieldTypeRichText\Validator\Constraints\RichTextValidator
      */
-    private $validator;
+    private RichTextValidator $validator;
 
     protected function setUp(): void
     {
@@ -137,7 +138,7 @@ class RichTextValidatorTest extends TestCase
 
     private function fetchErrorMessages(array $errors): array
     {
-        return array_map(static function (LibXMLError $error) {
+        return array_map(static function (LibXMLError $error): string {
             return $error->message;
         }, $errors);
     }


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

#### For QA:

Regression tests.
