### PR TITLE
IBX-9738: Link URL and title is removed when selecting full link text (pt 2)

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/link/link-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/link/link-ui.js
@@ -168,10 +168,14 @@ class IbexaLinkUI extends Plugin {
     }
 
     addLink() {
-        this.editor.focus();
-        this.editor.execute('insertIbexaLink', { href: '', title: '', target: '' });
+        const link = this.findLinkElement();
 
-        this.isNew = true;
+        if (!link) {
+            this.editor.focus();
+            this.editor.execute('insertIbexaLink', { href: '', title: '', target: '' });
+
+            this.isNew = true;
+        }
 
         this.showForm();
     }


### PR DESCRIPTION
| :ticket: Issue | [IBX-9738](https://issues.ibexa.co/browse/IBX-9738) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
