### PR TITLE
Fixed BC on XMLSanitizer

### DIFF
--- a/src/lib/RichText/DOMDocumentFactory.php
+++ b/src/lib/RichText/DOMDocumentFactory.php
@@ -41,7 +41,8 @@ final class DOMDocumentFactory
         // - substitute entities
         // - disable network access
         // - relax parser limits for document size/complexity
-        $success = $document->loadXML($this->xmlSanitizer->sanitizeXMLString($xmlString), LIBXML_NOENT | LIBXML_DTDLOAD | LIBXML_NONET | LIBXML_PARSEHUGE);
+        $xmlString = $this->xmlSanitizer->sanitizeXMLString($xmlString);
+        $success = $document->loadXML($xmlString, LIBXML_NOENT | LIBXML_DTDLOAD | LIBXML_NONET | LIBXML_PARSEHUGE);
         if (!$success) {
             throw new InvalidXmlException('$xmlString', libxml_get_errors());
         }

--- a/src/lib/RichText/XMLSanitizer.php
+++ b/src/lib/RichText/XMLSanitizer.php
@@ -20,7 +20,6 @@ final class XMLSanitizer
 {
     public function sanitizeXMLString(string $xmlString): string
     {
-        $xmlString = $this->decodeHTMLEntities($xmlString);
         $xmlString = $this->removeComments($xmlString);
         $xmlString = $this->removeDangerousTags($xmlString);
         $xmlString = $this->sanitizeDocType($xmlString);
@@ -43,11 +42,6 @@ final class XMLSanitizer
         }
 
         return $document;
-    }
-
-    private function decodeHTMLEntities(string $xmlString): string
-    {
-        return html_entity_decode($xmlString, ENT_XML1, 'UTF-8');
     }
 
     private function removeComments(string $xmlString): string
@@ -124,6 +118,7 @@ final class XMLSanitizer
         $entityDefinitions = [];
 
         foreach ($lines as $line) {
+            $line = html_entity_decode($line, ENT_XML1, 'UTF-8');
             $line = trim($line);
 
             if (preg_match('/<!ENTITY\s+(\S+)\s+(SYSTEM|PUBLIC)\s+/i', $line, $matches)) {

--- a/tests/lib/RichText/DOMDocumentFactoryTest.php
+++ b/tests/lib/RichText/DOMDocumentFactoryTest.php
@@ -71,6 +71,20 @@ EOT;
         $this->domDocumentFactory->loadXMLString($xml);
     }
 
+    public function testEncodedTagContentIsLeftAlone(): void
+    {
+        $xml = <<<EOT
+<?xml version="1.0"?>
+<para>By placing your order you agree to our <link>data &amp; privacy regulations</link>.</para>
+
+EOT;
+
+        $doc = $this->domDocumentFactory->loadXMLString($xml);
+        $docXMLString = $doc->saveXML();
+
+        self::assertSame($xml, $docXMLString);
+    }
+
     public function testRemoveEncodedEntities(): void
     {
         $xml = <<<EOT
@@ -114,7 +128,6 @@ EOT;
      */
     public function testHandleDoctype(string $xml, string $stringNotContainsString): void
     {
-        $xml =
         $doc = $this->domDocumentFactory->loadXMLString($xml);
         $docXMLString = $doc->saveXML();
         self::assertIsString($docXMLString);


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR fixes breaking change detected during release process.

XMLSanitizer no longer performs XML decoding on the whole document. Instead, decoding is done only when relevant lines are being processed (for safe entity detection), and is otherwise left alone and unchanged.

This prevents decoded XML (which is invalid) from making it's way into the `DOMDocumentFactory`.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
