### PR TITLE
IBX-9968: Resolved Symfony 7.x deprecations

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -22,4 +22,7 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_62,
         SymfonySetList::SYMFONY_63,
         SymfonySetList::SYMFONY_64,
+        SymfonySetList::SYMFONY_70,
+        SymfonySetList::SYMFONY_71,
+        SymfonySetList::SYMFONY_72,
    ]);

--- a/src/bundle/Resources/config/configuration.yaml
+++ b/src/bundle/Resources/config/configuration.yaml
@@ -53,4 +53,4 @@ services:
 
     Ibexa\FieldTypeRichText\Configuration\AggregateProvider:
         arguments:
-            $providers: !tagged ibexa.field_type.richtext.configuration.provider
+            $providers: !tagged_iterator ibexa.field_type.richtext.configuration.provider

--- a/src/bundle/Resources/config/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/fieldtype_services.yaml
@@ -85,7 +85,7 @@ services:
 
     Ibexa\FieldTypeRichText\RichText\Validator\ValidatorAggregate:
         class: Ibexa\FieldTypeRichText\RichText\Validator\ValidatorAggregate
-        arguments: [!tagged ibexa.field_type.richtext.validator.input.xhtml5]
+        arguments: [!tagged_iterator ibexa.field_type.richtext.validator.input.xhtml5]
 
     ibexa.richtext.validator.docbook:
         class: Ibexa\FieldTypeRichText\RichText\Validator\Validator

--- a/src/bundle/Resources/config/settings/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/settings/fieldtype_services.yaml
@@ -15,7 +15,7 @@ services:
 
     Ibexa\FieldTypeRichText\RichText\Validator\ValidatorAggregate:
         class: Ibexa\FieldTypeRichText\RichText\Validator\ValidatorAggregate
-        arguments: [!tagged ibexa.field_type.richtext.validator.input.xhtml5]
+        arguments: [!tagged_iterator ibexa.field_type.richtext.validator.input.xhtml5]
 
     ibexa.richtext.validator.docbook:
         class: Ibexa\FieldTypeRichText\RichText\Validator\Validator


### PR DESCRIPTION
| :ticket: Issue | IBX-9968  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled Rector Symfony 7.0, 7.1 and 7.2 sets. Resolved the following deprecations:

```
* [symfony/dependency-injection] Replaced deprecated !tagged YAML tag to !tagged_iterator 
```

#### For QA:

Sanities.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
