### PR TITLE
IBX-9727: [Tests] Fixed strict types after ibexa/core#590 changes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1639,12 +1639,6 @@ parameters:
 			path: tests/lib/RichText/Converter/LinkTest.php
 
 		-
-			message: '#^Parameter \#2 \$function of class Ibexa\\Core\\Base\\Exceptions\\UnauthorizedException constructor expects string, int given\.$#'
-			identifier: argument.type
-			count: 4
-			path: tests/lib/RichText/Converter/LinkTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\FieldTypeRichText\\RichText\\Converter\\Render\\EmbedTest\:\:providerForTestConvert\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/tests/lib/RichText/Converter/LinkTest.php
+++ b/tests/lib/RichText/Converter/LinkTest.php
@@ -275,7 +275,7 @@ class LinkTest extends TestCase
   </para>
 </section>',
                 106,
-                new APIUnauthorizedException('Location', 106),
+                new APIUnauthorizedException('content', 'read', ['Location' => 106]),
                 'notice',
                 'While generating links for richtext, unauthorized to load Location with ID 106',
             ],
@@ -295,7 +295,7 @@ class LinkTest extends TestCase
   </ezembed>
 </section>',
                 106,
-                new APIUnauthorizedException('Location', 106),
+                new APIUnauthorizedException('content', 'read', ['Location' => 106]),
                 'notice',
                 'While generating links for richtext, unauthorized to load Location with ID 106',
             ],
@@ -490,7 +490,7 @@ class LinkTest extends TestCase
   </para>
 </section>',
                 205,
-                new APIUnauthorizedException('Content', 205),
+                new APIUnauthorizedException('content', 'read', ['Content' => 205]),
                 'notice',
                 'While generating links for richtext, unauthorized to load Content object with ID 205',
             ],
@@ -510,7 +510,7 @@ class LinkTest extends TestCase
   </ezembed>
 </section>',
                 205,
-                new APIUnauthorizedException('Content', 205),
+                new APIUnauthorizedException('content', 'read', ['Content' => 205]),
                 'notice',
                 'While generating links for richtext, unauthorized to load Content object with ID 205',
             ],


### PR DESCRIPTION
| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/590


#### Description:

We were trying to incorrectly instantiate an `UnauthorizedException` (just for the purpose of mocking) and since ibexa/core#590 we can't get away with it.
Visible when running unit tests:
```
1) Error
The data provider specified for Ibexa\Tests\FieldTypeRichText\RichText\Converter\LinkTest::testConvertBadLocationLink is invalid.
TypeError: Ibexa\Core\Base\Exceptions\UnauthorizedException::__construct(): Argument #2 ($function) must be of type string, int given, called in /home/andrew/Product/packages/ibexa/fieldtype-richtext/tests/lib/RichText/Converter/LinkTest.php on line 278
/home/andrew/Product/packages/ibexa/fieldtype-richtext/vendor/ibexa/core/src/lib/Base/Exceptions/UnauthorizedException.php:37
/home/andrew/Product/packages/ibexa/fieldtype-richtext/tests/lib/RichText/Converter/LinkTest.php:278

2) Error
The data provider specified for Ibexa\Tests\FieldTypeRichText\RichText\Converter\LinkTest::testConvertBadContentLink is invalid.
TypeError: Ibexa\Core\Base\Exceptions\UnauthorizedException::__construct(): Argument #2 ($function) must be of type string, int given, called in /home/andrew/Product/packages/ibexa/fieldtype-richtext/tests/lib/RichText/Converter/LinkTest.php on line 493
/home/andrew/Product/packages/ibexa/fieldtype-richtext/vendor/ibexa/core/src/lib/Base/Exceptions/UnauthorizedException.php:37
/home/andrew/Product/packages/ibexa/fieldtype-richtext/tests/lib/RichText/Converter/LinkTest.php:493
```
