### PR TITLE
IBX-10228: Bump symfony/* requirement to ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,19 +15,19 @@
         "ibexa/core": "~5.0.x-dev",
         "ibexa/http-cache": "~5.0.x-dev",
         "ibexa/rest": "~5.0.x-dev",
-        "symfony/asset": "^7.2",
-        "symfony/cache": "^7.2",
-        "symfony/config": "^7.2",
-        "symfony/dependency-injection": "^7.2",
-        "symfony/form": "^7.2",
-        "symfony/http-kernel": "^7.2",
-        "symfony/options-resolver": "^7.2",
-        "symfony/security-core": "^7.2",
-        "symfony/templating": "^6.4",
-        "symfony/translation": "^7.2",
-        "symfony/translation-contracts": "^3.0",
-        "symfony/validator": "^7.2",
-        "symfony/yaml": "^7.2",
+        "symfony/asset": "^7.3",
+        "symfony/cache": "^7.3",
+        "symfony/config": "^7.3",
+        "symfony/dependency-injection": "^7.3",
+        "symfony/form": "^7.3",
+        "symfony/http-kernel": "^7.3",
+        "symfony/options-resolver": "^7.3",
+        "symfony/security-core": "^7.3",
+        "symfony/templating": "^7.3",
+        "symfony/translation": "^7.3",
+        "symfony/translation-contracts": "^7.3",
+        "symfony/validator": "^7.3",
+        "symfony/yaml": "^7.3",
         "twig/twig": "^3.0"
     },
     "require-dev": {
@@ -49,8 +49,8 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/finder": "^7.2",
-        "symfony/notifier": "^7.2"
+        "symfony/finder": "^7.3",
+        "symfony/notifier": "^7.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         "symfony/http-kernel": "^7.3",
         "symfony/options-resolver": "^7.3",
         "symfony/security-core": "^7.3",
-        "symfony/templating": "^7.3",
+        "symfony/templating": "^6.4",
         "symfony/translation": "^7.3",
-        "symfony/translation-contracts": "^7.3",
+        "symfony/translation-contracts": "^3.0",
         "symfony/validator": "^7.3",
         "symfony/yaml": "^7.3",
         "twig/twig": "^3.0"


### PR DESCRIPTION
| :ticket: Issue | IBX-10228    |
|----------------|--------------|

#### Description:
This PR updates all symfony/* dependencies to ^7.3.

#### For QA:
N/A

#### Documentation:
N/A

