### PR TITLE
fix: BaseRichText.getData() null safety - Added an early return

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
+++ b/src/bundle/Resources/public/js/CKEditor/core/base-ckeditor.js
@@ -52,6 +52,10 @@ const VIEWPORT_TOP_OFFSET_DISTRACTION_FREE_MODE = 0;
         }
 
         getData() {
+            if (!this.editor) {
+                return '';
+            }
+            
             const notTrimmedData = this.editor.getData({ trim: 'none' });
             const isDataEmpty = notTrimmedData === '<p>&nbsp;</p>';
 


### PR DESCRIPTION
Fixes the following console error I saw when clicking "Publish" in the editing view.
Might not be a bug but erroneous usage on my end... 
Nonethelesse, I would consider catching this scenario an improvement.

ibexa-richtext-onlineeditor-js.js:145040 Uncaught TypeError: Cannot read properties of null (reading 'getData')
at BaseRichText.getData (ibexa-richtext-onlin…tor-js.js:145040:42)
at RichTextValidator.validateInput (ibexa-admin-ui-conte…parts-js.js:9312:42)
at RichTextValidator.validateField (ibexa-admin-ui-conte…parts-js.js:5116:53)
at ibexa-admin-ui-conte…parts-js.js:5190:32
at Array.forEach (<anonymous>)
at RichTextValidator.isValid (ibexa-admin-ui-conte…parts-js.js:5188:31)
at getValidationResults (ibexa-admin-ui-conte…parts-js.js:4668:29)
at Array.map (<anonymous>)
at isFormValid (ibexa-admin-ui-conte…parts-js.js:4726:40)
at HTMLButtonElement.clickHandler (ibexa-admin-ui-conte…-parts-js.js:4710:9)

Somewhat related to https://github.com/ibexa/admin-ui/pull/1807