### PR TITLE
IBX-8798: Fixed link balloon behaviour in richtext editor

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/link/link-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/link/link-editing.js
@@ -10,8 +10,8 @@ class IbexaCustomTagEditing extends Plugin {
     }
 
     enableSelectionAttributesFixer() {
-        const model = this.editor.model;
-        const selection = model.document.selection;
+        const { model } = this.editor;
+        const { selection } = model.document;
 
         this.listenTo(selection, 'change:attribute', (_event, { attributeKeys }) => {
             if (!attributeKeys.includes('ibexaLinkHref') || selection.hasAttribute('ibexaLinkHref')) {

--- a/src/bundle/Resources/public/js/CKEditor/link/link-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/link/link-editing.js
@@ -13,7 +13,7 @@ class IbexaCustomTagEditing extends Plugin {
         const { model } = this.editor;
         const { selection } = model.document;
 
-        this.listenTo(selection, 'change:attribute', (_event, { attributeKeys }) => {
+        this.listenTo(selection, 'change:attribute', (event, { attributeKeys }) => {
             if (!attributeKeys.includes('ibexaLinkHref') || selection.hasAttribute('ibexaLinkHref')) {
                 return;
             }

--- a/src/bundle/Resources/public/js/CKEditor/link/link-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/link/link-editing.js
@@ -1,11 +1,27 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import TwoStepCaretMovement from '@ckeditor/ckeditor5-typing/src/twostepcaretmovement';
 
 import IbexaLinkCommand from './link-command';
 import { getCustomAttributesConfig, getCustomClassesConfig } from '../custom-attributes/helpers/config-helper';
 
 class IbexaCustomTagEditing extends Plugin {
     static get requires() {
-        return [];
+        return [TwoStepCaretMovement];
+    }
+
+    enableSelectionAttributesFixer() {
+        const model = this.editor.model;
+        const selection = model.document.selection;
+
+        this.listenTo(selection, 'change:attribute', (_event, { attributeKeys }) => {
+            if (!attributeKeys.includes('ibexaLinkHref') || selection.hasAttribute('ibexaLinkHref')) {
+                return;
+            }
+
+            model.change((writer) => {
+                writer.removeSelectionAttribute('ibexaLinkHref');
+            });
+        });
     }
 
     defineConverters(customAttributesLinkConfig, customClassesLinkConfig) {
@@ -149,6 +165,9 @@ class IbexaCustomTagEditing extends Plugin {
         if (customClassesLinkConfig) {
             this.editor.model.schema.extend('$text', { allowAttributes: 'ibexaLinkClasses' });
         }
+
+        this.editor.plugins.get(TwoStepCaretMovement).registerAttribute('ibexaLinkHref');
+        this.enableSelectionAttributesFixer();
 
         this.defineConverters(customAttributesLinkConfig, customClassesLinkConfig);
 

--- a/src/bundle/Resources/public/js/CKEditor/link/link-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/link/link-ui.js
@@ -19,6 +19,7 @@ class IbexaLinkUI extends Plugin {
         this.showForm = this.showForm.bind(this);
         this.addLink = this.addLink.bind(this);
         this.getLinkRange = this.getLinkRange.bind(this);
+        this.watchKeyboardLinkExit = this.watchKeyboardLinkExit.bind(this);
 
         this.isNew = false;
     }
@@ -39,6 +40,7 @@ class IbexaLinkUI extends Plugin {
             const { url, title, target, ibexaLinkClasses, ibexaLinkAttributes, siteaccess } = this.formView.getValues();
             const { path: firstPosition } = this.editor.model.document.selection.getFirstPosition();
             const { path: lastPosition } = this.editor.model.document.selection.getLastPosition();
+            const originalSelectionLastPosition = this.editor.model.document.selection.getLastPosition();
             const noRangeSelection = firstPosition[0] === lastPosition[0] && firstPosition[1] === lastPosition[1];
 
             const isValueValid = this.isValueValid(url);
@@ -57,13 +59,21 @@ class IbexaLinkUI extends Plugin {
                 });
             }
 
+            this.stopListening(this.editor.ui, 'update');
             this.isNew = false;
 
             this.editor.execute('insertIbexaLink', { href: url, title, target, siteaccess, ibexaLinkClasses, ibexaLinkAttributes });
+
+            this.editor.model.change((writer) => {
+                writer.setSelection(writer.createPositionFromPath(originalSelectionLastPosition.root, originalSelectionLastPosition.path));
+                writer.removeSelectionAttribute('ibexaLinkHref');
+            });
+
             this.hideForm();
         });
 
         this.listenTo(formView, 'remove-link', () => {
+            this.stopListening(this.editor.ui, 'update');
             this.removeLink();
             this.hideForm();
         });
@@ -152,9 +162,12 @@ class IbexaLinkUI extends Plugin {
         });
 
         this.balloon.updatePosition(this.getBalloonPositionData());
+        this.watchKeyboardLinkExit();
     }
 
     hideForm() {
+        this.stopListening(this.editor.ui, 'update');
+
         if (this.isNew) {
             this.editor.model.change((writer) => {
                 const ranges = this.editor.model.schema.getValidRanges(this.editor.model.document.selection.getRanges(), 'ibexaLinkHref');
@@ -204,6 +217,23 @@ class IbexaLinkUI extends Plugin {
             activator: () => this.balloon.hasView(this.formView),
             contextElements: [this.balloon.view.element, document.querySelector('#react-udw')],
             callback: () => this.hideForm(),
+        });
+    }
+
+    watchKeyboardLinkExit() {
+        let prevSelectedLink = this.findLinkElement();
+
+        this.listenTo(this.editor.ui, 'update', () => {
+            const selectedLink = this.findLinkElement();
+            const hasLeftLinkByKeyboard = prevSelectedLink && !selectedLink;
+
+            if (hasLeftLinkByKeyboard) {
+                this.hideForm();
+
+                return;
+            }
+
+            prevSelectedLink = selectedLink;
         });
     }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8798 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This pr enable user to exit a link and continue typing plain text on the same line, and resolves the issue with the link balloon not closing when the cursor position is changed via the arrow keys.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
