### PR TITLE
IBX-11304: Prevented custom tag from disappearing when the added imag…

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-ui.js
@@ -220,6 +220,7 @@ class IbexaCustomTagUI extends Plugin {
             return outputValues;
         }, {});
 
+        this.editor.focus();
         this.editor.execute('insertIbexaCustomTag', { customTagName: this.componentName, values });
 
         if (this.hasAttributes()) {

--- a/src/bundle/Resources/public/js/CKEditor/remove-element/remove-element-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/remove-element/remove-element-ui.js
@@ -12,6 +12,7 @@ class IbexaRemoveElementUI extends Plugin {
     }
 
     removeBlock() {
+        this.editor.editing.view.focus();
         this.editor.execute('ibexaRemoveElement');
     }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-11304 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This changes fixes issue with disappearing custom tag when the added image loses focus. It also fixes the console error that occurs when an image or tag is deleted.


#### For QA:
Update: there is already reported issue with mentioned error: 
- https://github.com/ibexa/fieldtype-richtext/pull/250   :ticket: IBX-9975 
probably related to this issue: https://ibexa.atlassian.net/browse/IBX-10270

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
