### PR TITLE
IBX-11615: Inline custom tag renders empty content when inline string is 0

### DIFF
--- a/src/lib/RichText/Converter/Render/Template.php
+++ b/src/lib/RichText/Converter/Render/Template.php
@@ -95,7 +95,7 @@ class Template extends Render implements Converter
         foreach ($contentNodes as $contentNode) {
             $innerContent .= $this->getCustomTemplateContent($contentNode);
         }
-        $parameters['content'] = !empty($innerContent) ? $innerContent : null;
+        $parameters['content'] = $innerContent !== '' ? $innerContent : null;
 
         foreach ($this->getAttributesMap() as $attribute => $param) {
             if ($template->hasAttribute($attribute)) {


### PR DESCRIPTION
| :ticket: Issue | IBX-11615 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
