### PR TITLE
IBX-11697: Added missing import in custom-tag-editing.js

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
@@ -1,6 +1,7 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import { toWidget, toWidgetEditable } from '@ckeditor/ckeditor5-widget/src/utils';
+import Element from '@ckeditor/ckeditor5-engine/src/view/element';
 
 import IbexaCustomTagCommand from './custom-tag-command';
 

--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-editing.js
@@ -117,7 +117,7 @@ class IbexaCustomTagEditing extends Plugin {
                 const values = {};
 
                 for (const configValue of configValuesIterator) {
-                    if (configValue instanceof Element === false && typeof configValue !== 'object') {
+                    if (configValue instanceof Element === false) {
                         continue;
                     }
 

--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-ui.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/block-custom-tag/custom-tag-ui.js
@@ -158,7 +158,7 @@ class IbexaCustomTagUI extends Plugin {
             if (this.config.attributes[key]?.type === 'boolean') {
                 return {
                     ...output,
-                    [key]: value === true || value === 'true',
+                    [key]: value === 'true',
                 };
             }
 

--- a/src/bundle/Resources/public/js/CKEditor/custom-tags/ui/custom-tag-form-view.js
+++ b/src/bundle/Resources/public/js/CKEditor/custom-tags/ui/custom-tag-form-view.js
@@ -98,7 +98,7 @@ class IbexaCustomTagFormView extends View {
     }
 
     setBooleanValue(attributeView, value) {
-        attributeView.fieldView.isOn = value === true || value === 'true';
+        attributeView.fieldView.isOn = value === 'true';
         attributeView.fieldView.element.value = value;
         attributeView.fieldView.set('value', value);
         attributeView.fieldView.set('isEmpty', false);


### PR DESCRIPTION
| :ticket: Issue | IBX-11697 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This fix is related to changes introduced in this pr - https://github.com/ibexa/fieldtype-richtext/pull/285
This check has been added:
```
 if (configValue instanceof Element === false) {
                        continue;
                    }
```
Element import was missing resulting in the buggy behavior described in the 3rd line.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
