### PR TITLE
IBX-11834: Load embedded images in batch when editing rich text field

### DIFF
--- a/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-command.js
+++ b/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-command.js
@@ -10,7 +10,7 @@ class IbexaEmbedImageCommand extends Command {
     }
 
     createEmbed(writer, { contentId, size }) {
-        return writer.createElement('embedImage', { contentId, size });
+        return writer.createElement('embedImage', { contentId: contentId?.toString(), size });
     }
 }
 

--- a/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
@@ -4,7 +4,7 @@ import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 
 import IbexaEmbedImageCommand from './embed-image-command';
 
-import { findContent } from '../../services/content-service';
+import { findContents } from '../../services/content-service';
 import { getCustomClassesConfig, addPredefinedClassToConfig } from '../../custom-attributes/helpers/config-helper';
 
 const CONTAINER_CLASS = 'ibexa-embed-type-image';
@@ -18,24 +18,63 @@ class IbexaEmbedImageEditing extends Plugin {
         super(props);
 
         this.loadImagePreview = this.loadImagePreview.bind(this);
+        this.loadPendingImagePreviews = this.loadPendingImagePreviews.bind(this);
         this.loadImageVariation = this.loadImageVariation.bind(this);
         this.getSetting = this.getSetting.bind(this);
+
+        this.pendingImagePreviewLoads = new Set();
+        this.pendingImagePreviewLoad = null;
 
         addPredefinedClassToConfig('embedImage', CONTAINER_CLASS);
     }
 
     loadImagePreview(modelElement) {
-        const contentId = modelElement.getAttribute('contentId');
+        this.pendingImagePreviewLoads.add(modelElement);
+
+        if (this.pendingImagePreviewLoad === null) {
+            this.pendingImagePreviewLoad = Promise.resolve().then(this.loadPendingImagePreviews);
+        }
+    }
+
+    loadPendingImagePreviews() {
+        const modelElements = [...this.pendingImagePreviewLoads];
+        const contentIds = [...new Set(modelElements.map((modelElement) => modelElement.getAttribute('contentId')).filter(Boolean))];
         const token = document.querySelector('meta[name="CSRF-Token"]').content;
         const siteaccess = document.querySelector('meta[name="SiteAccess"]').content;
 
-        findContent({ token, siteaccess, contentId }, (contents) => {
-            const fields = contents[0].CurrentVersion.Version.Fields.field;
-            const fieldImage = fields.find((field) => field.fieldTypeIdentifier === 'ezimage');
-            const size = modelElement.getAttribute('size');
-            const variationHref = fieldImage.fieldValue.variations[size].href;
+        this.pendingImagePreviewLoads.clear();
+        this.pendingImagePreviewLoad = null;
 
-            this.loadImageVariation(modelElement, variationHref);
+        if (!contentIds.length) {
+            return;
+        }
+
+        findContents({ token, siteaccess, contentIds }, (contents) => {
+            const contentsById = contents.reduce((map, content) => {
+                const contentId = content._id ?? content.id;
+
+                if (contentId) {
+                    map[`${contentId}`] = content;
+                }
+
+                return map;
+            }, {});
+
+            modelElements.forEach((modelElement) => {
+                const contentId = modelElement.getAttribute('contentId');
+                const content = contentsById[`${contentId}`];
+
+                if (!content) {
+                    return;
+                }
+
+                const fields = content.CurrentVersion.Version.Fields.field;
+                const fieldImage = fields.find((field) => field.fieldTypeIdentifier === 'ezimage');
+                const size = modelElement.getAttribute('size');
+                const variationHref = fieldImage.fieldValue.variations[size].href;
+
+                this.loadImageVariation(modelElement, variationHref);
+            });
         });
     }
 

--- a/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
+++ b/src/bundle/Resources/public/js/CKEditor/embed/image/embed-image-editing.js
@@ -6,6 +6,7 @@ import IbexaEmbedImageCommand from './embed-image-command';
 
 import { findContents } from '../../services/content-service';
 import { getCustomClassesConfig, addPredefinedClassToConfig } from '../../custom-attributes/helpers/config-helper';
+import { getUniqueAttrValues } from '../../helpers/models';
 
 const CONTAINER_CLASS = 'ibexa-embed-type-image';
 
@@ -22,28 +23,30 @@ class IbexaEmbedImageEditing extends Plugin {
         this.loadImageVariation = this.loadImageVariation.bind(this);
         this.getSetting = this.getSetting.bind(this);
 
-        this.pendingImagePreviewLoads = new Set();
-        this.pendingImagePreviewLoad = null;
+        this.pendingImagePreviewModelElements = new Set();
+        this.loadingImageAlreadyBatched = false;
 
         addPredefinedClassToConfig('embedImage', CONTAINER_CLASS);
     }
 
     loadImagePreview(modelElement) {
-        this.pendingImagePreviewLoads.add(modelElement);
+        this.pendingImagePreviewModelElements.add(modelElement);
 
-        if (this.pendingImagePreviewLoad === null) {
-            this.pendingImagePreviewLoad = Promise.resolve().then(this.loadPendingImagePreviews);
+        if (!this.loadingImageAlreadyBatched) {
+            this.loadingImageAlreadyBatched = true;
+
+            queueMicrotask(this.loadPendingImagePreviews);
         }
     }
 
     loadPendingImagePreviews() {
-        const modelElements = [...this.pendingImagePreviewLoads];
-        const contentIds = [...new Set(modelElements.map((modelElement) => modelElement.getAttribute('contentId')).filter(Boolean))];
+        const modelElements = [...this.pendingImagePreviewModelElements];
+        const contentIds = getUniqueAttrValues(modelElements, 'contentId');
         const token = document.querySelector('meta[name="CSRF-Token"]').content;
         const siteaccess = document.querySelector('meta[name="SiteAccess"]').content;
 
-        this.pendingImagePreviewLoads.clear();
-        this.pendingImagePreviewLoad = null;
+        this.pendingImagePreviewModelElements.clear();
+        this.loadingImageAlreadyBatched = false;
 
         if (!contentIds.length) {
             return;
@@ -54,7 +57,7 @@ class IbexaEmbedImageEditing extends Plugin {
                 const contentId = content._id ?? content.id;
 
                 if (contentId) {
-                    map[`${contentId}`] = content;
+                    map[contentId] = content;
                 }
 
                 return map;
@@ -62,7 +65,7 @@ class IbexaEmbedImageEditing extends Plugin {
 
             modelElements.forEach((modelElement) => {
                 const contentId = modelElement.getAttribute('contentId');
-                const content = contentsById[`${contentId}`];
+                const content = contentsById[contentId];
 
                 if (!content) {
                     return;

--- a/src/bundle/Resources/public/js/CKEditor/helpers/models.js
+++ b/src/bundle/Resources/public/js/CKEditor/helpers/models.js
@@ -1,0 +1,5 @@
+export const getUniqueAttrValues = (models, attr) => {
+    const attrValues = models.map((model) => model.getAttribute(attr)).filter(Boolean);
+
+    return [...new Set(attrValues)];
+};

--- a/src/bundle/Resources/public/js/CKEditor/services/content-service.js
+++ b/src/bundle/Resources/public/js/CKEditor/services/content-service.js
@@ -1,5 +1,5 @@
 export const findContents = ({ token, siteaccess, contentIds, limit = contentIds.length, offset = 0 }, callback) => {
-    const ids = [...new Set(contentIds.map((contentId) => `${contentId}`))];
+    const ids = [...new Set(contentIds)];
 
     if (!ids.length) {
         callback([]);

--- a/src/bundle/Resources/public/js/CKEditor/services/content-service.js
+++ b/src/bundle/Resources/public/js/CKEditor/services/content-service.js
@@ -1,12 +1,20 @@
-export const findContent = ({ token, siteaccess, contentId, limit = 1, offset = 0 }, callback) => {
+export const findContents = ({ token, siteaccess, contentIds, limit = contentIds.length, offset = 0 }, callback) => {
+    const ids = [...new Set(contentIds.map((contentId) => `${contentId}`))];
+
+    if (!ids.length) {
+        callback([]);
+
+        return;
+    }
+
     const body = JSON.stringify({
         ViewInput: {
-            identifier: `find-content-${contentId}`,
+            identifier: `find-content-${ids.join('-')}`,
             public: false,
             ContentQuery: {
                 FacetBuilders: {},
                 SortClauses: {},
-                Filter: { ContentIdCriterion: `${contentId}` },
+                Filter: { ContentIdCriterion: ids.join() },
                 limit,
                 offset,
             },
@@ -33,4 +41,8 @@ export const findContent = ({ token, siteaccess, contentId, limit = 1, offset = 
             callback(items);
         })
         .catch(window.ibexa.helpers.notification.showErrorNotification);
+};
+
+export const findContent = ({ token, siteaccess, contentId, limit = 1, offset = 0 }, callback) => {
+    findContents({ token, siteaccess, contentIds: [contentId], limit, offset }, callback);
 };


### PR DESCRIPTION
| :ticket: Issue | IBX-11834 |
|----------------|-----------|

#### Description:
This change adds a batched `findContents()` helper for View API content lookups while keeping `findContent()` as a compatibility wrapper for existing single-content callers. 

Embedded image preview loading now collects pending image embeds during the current CKEditor's conversion pass, and resolves them with one `/api/ibexa/v2/views` request before continuing with  the variation loading flow.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
