### PR TITLE
IBX-12050: Fixed floating images

### DIFF
--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -193,7 +193,7 @@
         margin: calculateRem(16px) auto;
     }
 
-    [data-ezalign] + * {
+    [data-ezalign] + div.ck-widget {
         clear: both;
     }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-12050|
|----------------|-----------|

PR fixes a little issue introduced by https://github.com/ibexa/fieldtype-richtext/pull/242

Currently, the element immediately following to an aligned image has `clear: both;` assigned.

PR adds `clear: both;`  to such element only, if it is a `div.ck-widget` element.

Behavior is then:
- Image `float: right;`, followed by a paragraph
<img width="297" height="140" alt="image-right-text" src="https://github.com/user-attachments/assets/f65cfb6e-b792-40b5-a2e6-5b30b1975efd" />
<hr>

- Image `float: left;`, followed by a paragraph
<img width="300" height="152" alt="image-left-text" src="https://github.com/user-attachments/assets/80009992-032e-400d-bf6f-34ac9c2627d9" />
<hr>

- Image `float: right;`, followed by a video
<img width="301" height="174" alt="image-right-video" src="https://github.com/user-attachments/assets/f4ae6f6f-af1b-49bd-8f1c-c0b0d628eb8d" />
<hr>

- Image `float: left;`, followed by a video
<img width="296" height="166" alt="image-left-video" src="https://github.com/user-attachments/assets/6104bf49-8cec-45cc-b29d-0ef28dee3698" />
