### PR TITLE
IBX-12043: Replace deprecated PARAM_STR_ARRAY with ArrayParameterType

### DIFF
--- a/src/lib/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
+++ b/src/lib/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\FieldTypeRichText\FieldType\RichText\RichTextStorage\Gateway;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Ibexa\Core\FieldType\Url\UrlStorage\Gateway as UrlGateway;
 use Ibexa\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
@@ -45,7 +46,7 @@ class DoctrineStorage extends Gateway
                 )
                 ->from(ContentGateway::CONTENT_ITEM_TABLE)
                 ->where($query->expr()->in('remote_id', ':remoteIds'))
-                ->setParameter('remoteIds', $remoteIds, Connection::PARAM_STR_ARRAY)
+                ->setParameter('remoteIds', $remoteIds, ArrayParameterType::STRING)
             ;
 
             $statement = $query->executeQuery();


### PR DESCRIPTION
## Why

DBAL 3.10 deprecates `Connection::PARAM_STR_ARRAY`/`PARAM_INT_ARRAY`; DBAL 4 removes them. Forward-compat cleanup ahead of the DBAL 4 bump — no behavior change.

## Changes

- `DoctrineStorage.php`: `Connection::PARAM_STR_ARRAY` → `ArrayParameterType::STRING`.

## Test plan

- [x] `php -l` clean
- [x] Repo-wide grep confirms zero remaining `PARAM_STR_ARRAY`/`PARAM_INT_ARRAY` usages
- [x] `composer test` — 400 tests, 915 assertions, 1 skipped, all passing